### PR TITLE
Add batch calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
@@ -25,6 +26,7 @@ default = ["std"]
 std = [
     "pallet-balances/std",
     "parity-scale-codec/std",
+    "pallet-utility/std",
     "frame-support/std",
     "frame-system/std",
     "sp-core/std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-
-[dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
+
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,15 @@ mod tests;
 pub mod pallet {
 
 	use frame_support::dispatch::fmt::Debug;
+	use frame_support::dispatch::{
+		Dispatchable, GetDispatchInfo, PostDispatchInfo, UnfilteredDispatchable,
+	};
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::Currency;
+	use frame_support::weights::extract_actual_weight;
 	use frame_system::pallet_prelude::*;
 	use log::warn;
+	use pallet_utility::{Config as UtilityConfig, WeightInfo};
 	use sp_core::crypto::AccountId32;
 	use sp_runtime::traits::Saturating;
 	use sp_runtime::traits::Verify;
@@ -94,7 +99,11 @@ pub mod pallet {
 
 	/// Configuration trait of this pallet.
 	#[pallet::config]
-	pub trait Config: frame_system::Config {
+	pub trait Config: frame_system::Config + UtilityConfig {
+		type Call: Parameter
+			+ Dispatchable<Origin = Self::Origin, PostInfo = PostDispatchInfo>
+			+ GetDispatchInfo
+			+ UnfilteredDispatchable<Origin = Self::Origin>;
 		/// The overarching event type
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
@@ -275,6 +284,71 @@ pub mod pallet {
 
 			Ok(Default::default())
 		}
+
+		// Copy-paste from https://docs.rs/pallet-utility/3.0.0/pallet_utility/
+		#[pallet::weight(0)]
+		pub fn batch_calls(
+			origin: OriginFor<T>,
+			calls: Vec<<T as Config>::Call>,
+		) -> DispatchResultWithPostInfo {
+			let is_root = ensure_root(origin.clone()).is_ok();
+			let calls_len = calls.len();
+			// Track the actual weight of each of the batch calls.
+			let mut weight: Weight = 0;
+			for (index, call) in calls.into_iter().enumerate() {
+				let info = call.get_dispatch_info();
+				// If origin is root, don't apply any dispatch filters; root can call anything.
+				let result = if is_root {
+					call.dispatch_bypass_filter(origin.clone())
+				} else {
+					call.dispatch(origin.clone())
+				};
+				// Add the weight of this call.
+				weight = weight.saturating_add(extract_actual_weight(&result, &info));
+				if let Err(e) = result {
+					Self::deposit_event(Event::BatchInterrupted(index as u32, e.error));
+					// Take the weight of this function itself into account.
+					let base_weight = T::WeightInfo::batch(index.saturating_add(1) as u32);
+					// Return the actual used weight + base_weight of this call.
+					return Ok(Some(base_weight + weight).into());
+				}
+			}
+			Self::deposit_event(Event::BatchCompleted);
+			let base_weight = T::WeightInfo::batch(calls_len as u32);
+			Ok(Some(base_weight + weight).into())
+		}
+
+		/// Initialize the reward distribution storage. It shortcuts whenever an error is found
+		/// We can change this behavior to check this beforehand if we prefer
+		#[pallet::weight(0)]
+		pub fn initialize_reward_vec(
+			origin: OriginFor<T>,
+			contributions: Vec<(T::RelayChainAccountId, Option<T::AccountId>, u32)>,
+			reward_ratio: u32,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			for (relay_account, native_account, contribution) in contributions {
+				ensure!(
+					ClaimedRelayChainIds::<T>::get(&relay_account).is_none()
+						&& UnassociatedContributions::<T>::get(&relay_account).is_none(),
+					Error::<T>::AlreadyInitialized
+				);
+				let reward_info = RewardInfo {
+					total_reward: BalanceOf::<T>::from(contribution)
+						.saturating_mul(BalanceOf::<T>::from(reward_ratio)),
+					claimed_reward: 0u32.into(),
+					last_paid: 0u32.into(),
+				};
+
+				if let Some(native_account) = native_account {
+					AccountsPayable::<T>::insert(&native_account, reward_info);
+					ClaimedRelayChainIds::<T>::insert(&relay_account, ());
+				} else {
+					UnassociatedContributions::<T>::insert(&relay_account, reward_info);
+				}
+			}
+			Ok(Default::default())
+		}
 	}
 
 	#[pallet::error]
@@ -282,6 +356,7 @@ pub mod pallet {
 		/// User trying to associate a native identity with a relay chain identity for posterior
 		/// reward claiming provided an already associated relay chain identity
 		AlreadyAssociated,
+		AlreadyInitialized,
 		/// User trying to associate a native identity with a relay chain identity for posterior
 		/// reward claiming provided a wrong signature
 		InvalidClaimSignature,
@@ -378,6 +453,11 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(fn deposit_event)]
 	pub enum Event<T: Config> {
+		/// Batch of dispatches did not complete fully. Index of first failing dispatch given, as
+		/// well as the error. \[index, error\]
+		BatchInterrupted(u32, DispatchError),
+		/// Batch of dispatches completed fully with no error.
+		BatchCompleted,
 		/// Someone has proven they made a contribution and associated a native identity with it.
 		/// Data is the relay account,  native account and the total amount of _rewards_ that will be paid
 		NativeIdentityAssociated(T::RelayChainAccountId, T::AccountId, BalanceOf<T>),

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -17,9 +17,8 @@
 //! Test utilities
 use crate::{self as pallet_crowdloan_rewards, Config};
 use frame_support::{
-	construct_runtime,
-	parameter_types,
-	traits::{GenesisBuild, OnInitialize, OnFinalize},
+	construct_runtime, parameter_types,
+	traits::{GenesisBuild, OnFinalize, OnInitialize},
 };
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
@@ -35,7 +34,6 @@ pub type Balance = u128;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
- 
 
 construct_runtime!(
 	pub enum Test where
@@ -101,7 +99,6 @@ parameter_types! {
 
 impl Config for Test {
 	type Event = Event;
-	type Call = Call;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;
@@ -133,6 +130,8 @@ fn genesis(
 	ext.execute_with(|| System::set_block_number(1));
 	ext
 }
+
+pub type UtilityCall = pallet_utility::Call<Test>;
 
 pub(crate) fn get_ed25519_pairs(num: u32) -> Vec<ed25519::Pair> {
 	let seed: u128 = 12345678901234567890123456789012;
@@ -179,6 +178,21 @@ pub(crate) fn events() -> Vec<super::Event<Test>> {
 		})
 		.collect::<Vec<_>>()
 }
+
+pub(crate) fn batch_events() -> Vec<pallet_utility::Event> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.filter_map(|e| {
+			if let Event::pallet_utility(inner) = e {
+				Some(inner)
+			} else {
+				None
+			}
+		})
+		.collect::<Vec<_>>()
+}
+
 pub(crate) fn roll_to(n: u64) {
 	while System::block_number() < n {
 		Crowdloan::on_finalize(System::block_number());

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -71,6 +71,7 @@ impl frame_system::Config for Test {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type OnSetCode = ();
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -16,18 +16,14 @@
 
 //! Test utilities
 use crate::{self as pallet_crowdloan_rewards, Config};
-use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{OnFinalize, OnInitialize},
-};
+use frame_support::{construct_runtime, parameter_types};
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 };
-use sp_std::convert::From;
-use sp_std::convert::TryInto;
+use sp_std::convert::{From, TryInto};
 
 pub type AccountId = u64;
 pub type Balance = u128;
@@ -193,13 +189,6 @@ pub(crate) fn batch_events() -> Vec<pallet_utility::Event> {
 
 pub(crate) fn roll_to(n: u64) {
 	while System::block_number() < n {
-		Crowdloan::on_finalize(System::block_number());
-		Balances::on_finalize(System::block_number());
-		System::on_finalize(System::block_number());
 		System::set_block_number(System::block_number() + 1);
-		System::on_initialize(System::block_number());
-		Balances::on_initialize(System::block_number());
-		Crowdloan::on_initialize(System::block_number());
-		Utility::on_initialize(System::block_number());
 	}
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -121,7 +121,14 @@ fn genesis(contributions: Vec<([u8; 32], Option<AccountId>, u32)>) -> sp_io::Tes
 
 	let mut ext = sp_io::TestExternalities::from(storage);
 	ext.execute_with(|| {
-		Crowdloan::initialize_reward_vec(Origin::root(), contributions.clone(), 1, 0, contributions.len() as u32).unwrap();
+		Crowdloan::initialize_reward_vec(
+			Origin::root(),
+			contributions.clone(),
+			1,
+			0,
+			contributions.len() as u32,
+		)
+		.unwrap();
 		System::set_block_number(1)
 	});
 	ext

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -17,8 +17,9 @@
 //! Test utilities
 use crate::{self as pallet_crowdloan_rewards, Config};
 use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{GenesisBuild, OnFinalize, OnInitialize},
+	construct_runtime,
+	parameter_types,
+	traits::{GenesisBuild, OnInitialize, OnFinalize},
 };
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
@@ -34,6 +35,7 @@ pub type Balance = u128;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
+ 
 
 construct_runtime!(
 	pub enum Test where
@@ -44,6 +46,7 @@ construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		Crowdloan: pallet_crowdloan_rewards::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Utility: pallet_utility::{Pallet, Call, Storage, Event},
 	}
 );
 
@@ -98,9 +101,16 @@ parameter_types! {
 
 impl Config for Test {
 	type Event = Event;
+	type Call = Call;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;
+}
+
+impl pallet_utility::Config for Test {
+	type Event = Event;
+	type Call = Call;
+	type WeightInfo = ();
 }
 
 fn genesis(
@@ -178,5 +188,6 @@ pub(crate) fn roll_to(n: u64) {
 		System::on_initialize(System::block_number());
 		Balances::on_initialize(System::block_number());
 		Crowdloan::on_initialize(System::block_number());
+		Utility::on_initialize(System::block_number());
 	}
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -95,10 +95,14 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
+	pub const TestLeasePeriod: u64 = 10;
+	pub const TestDefaultNextInitialization: u64 = 0;
 }
 
 impl Config for Test {
 	type Event = Event;
+	type LeasePeriod = TestLeasePeriod;
+	type DefaultNextInitialization = TestDefaultNextInitialization;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;
@@ -117,7 +121,7 @@ fn genesis(contributions: Vec<([u8; 32], Option<AccountId>, u32)>) -> sp_io::Tes
 
 	let mut ext = sp_io::TestExternalities::from(storage);
 	ext.execute_with(|| {
-		Crowdloan::initialize_reward_vec(Origin::root(), contributions, 1).unwrap();
+		Crowdloan::initialize_reward_vec(Origin::root(), contributions.clone(), 1, 0, contributions.len() as u32).unwrap();
 		System::set_block_number(1)
 	});
 	ext

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,23 +229,30 @@ fn initialize_new_addresses() {
 			Crowdloan::initialize_reward_vec(
 				Origin::root(),
 				vec![([1u8; 32].into(), Some(1), 500)],
+				1,
+				0,
 				1
 			),
 			Error::<Test>::AlreadyInitialized
 		);
 		assert_ok!(
 			mock::Call::Utility(UtilityCall::batch(vec![mock::Call::Crowdloan(
-				crate::Call::initialize_reward_vec(vec![([1u8; 32].into(), Some(1), 500)], 1)
+				crate::Call::initialize_reward_vec(vec![([1u8; 32].into(), Some(1), 500)], 1, 0,
+				1)
 			)]))
 			.dispatch(Origin::root())
 		);
 		assert_ok!(mock::Call::Utility(UtilityCall::batch(vec![
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
 				vec![(pairs[4].public().into(), Some(3), 500)],
+				1,
+				0,
 				1
 			)),
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
 				vec![([1u8; 32].into(), Some(1), 500)],
+				1,
+				0,
 				1
 			))
 		]))
@@ -257,10 +264,14 @@ fn initialize_new_addresses() {
 		assert_ok!(mock::Call::Utility(UtilityCall::batch(vec![
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
 				vec![(pairs[5].public().into(), Some(6), 500)],
+				1,
+				0,
 				1
 			)),
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
 				vec![(pairs[6].public().into(), Some(7), 500)],
+				1,
+				0,
 				1
 			))
 		]))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -236,32 +236,23 @@ fn initialize_new_addresses() {
 		);
 		assert_eq!(Crowdloan::next_initialization(), 10);
 		roll_to(10);
-		assert_noop!(
-			Crowdloan::initialize_reward_vec(
-				Origin::root(),
-				vec![([1u8; 32].into(), Some(1), 500)],
-				1,
-				0,
-				1
-			),
-			Error::<Test>::AlreadyInitialized
-		);
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
+				([1u8; 32].into(), Some(1), 500),
 				([4u8; 32].into(), Some(4), 500),
 				([5u8; 32].into(), None, 500)
 			],
 			1,
 			0,
-			3
+			4
 		));
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![([6u8; 32].into(), Some(6), 500)],
 			1,
-			2,
-			3
+			3,
+			4
 		));
 		assert_noop!(
 			Crowdloan::initialize_reward_vec(
@@ -274,6 +265,12 @@ fn initialize_new_addresses() {
 			Error::<Test>::CurrentLeasePeriodAlreadyInitialized
 		);
 		assert_eq!(Crowdloan::next_initialization(), 20);
+		let expected = vec![crate::Event::ErrorWhileInitializing(
+			[1u8; 32],
+			Some(1),
+			500,
+		)];
+		assert_eq!(events(), expected);
 	});
 }
 
@@ -311,7 +308,7 @@ fn initialize_new_addresses_with_batch() {
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 2,
+					error: 1,
 					message: None,
 				},
 			),


### PR DESCRIPTION
This PR:

- Removes the Genesis config and building as the reward vector will be initalized through democracy proposals/sudo
- Adds Initialize_vec_reward dispatachable that initializes the contributions vector accordingly. This function ensures that `NextInitialization` < `now` and that the accountId is not already initialized. It also updates `NextInitialization` if the `index` + `len(contributions)` is equal to `limit`. The reason behind this is that this function will be called trough batch calls, and threfore we cannot update the storage until we are sure all batch calls have been dispatched. 
- Installs pallet_utility in the test runtime to unitest reward initialization with batch calls
- Unitests all the aforementioned behavior

TODO: what do we expect to happen when one batch call fails?
- I would just do nothing if one of the contributions is invalid, i.e., keep adding the following one. If we want the whole process to stop if one of them is invalid then we need another storage value counting the index until which we performed valid batch calls. I think this might be overkill, as we will have the relay chain state read method to add a contributor as well. 