### PR TITLE
Minimum payable should be one if contribution less than vesting period and MinimumContribution checks added

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ pub mod pallet {
 		type DefaultNextInitialization: Get<Self::BlockNumber>;
 		/// The overarching event type
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		/// The period after which the contribution storage can be initialized again
+		type MinimumContribution: Get<BalanceOf<Self>>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
 		type RewardCurrency: Currency<Self::AccountId>;
 
@@ -198,6 +200,11 @@ pub mod pallet {
 			ensure!(
 				info.claimed_reward < info.total_reward,
 				Error::<T>::RewardsAlreadyClaimed
+			);
+
+			ensure!(
+				info.total_reward > T::MinimumContribution::get(),
+				Error::<T>::ContributionNotHighEnough
 			);
 			let now = frame_system::Pallet::<T>::block_number();
 
@@ -338,6 +345,8 @@ pub mod pallet {
 		/// User trying to associate a native identity with a relay chain identity for posterior
 		/// reward claiming provided an already associated relay chain identity
 		AlreadyAssociated,
+		/// The contribution is not high enough to be eligible for rewards
+		ContributionNotHighEnough,
 		/// Current Lease Period has already been initialized
 		CurrentLeasePeriodAlreadyInitialized,
 		/// User trying to associate a native identity with a relay chain identity for posterior

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -94,7 +94,7 @@ parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
 	pub const TestLeasePeriod: u64 = 10;
 	pub const TestDefaultNextInitialization: u64 = 0;
-	pub const TestMinimumContribution: u128 = 0;
+	pub const TestMinimumContribution: u128 = 2;
 }
 
 impl Config for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -94,12 +94,14 @@ parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
 	pub const TestLeasePeriod: u64 = 10;
 	pub const TestDefaultNextInitialization: u64 = 0;
+	pub const TestMinimumContribution: u128 = 0;
 }
 
 impl Config for Test {
 	type Event = Event;
 	type LeasePeriod = TestLeasePeriod;
 	type DefaultNextInitialization = TestDefaultNextInitialization;
+	type MinimumContribution = TestMinimumContribution;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -160,6 +160,14 @@ pub(crate) fn two_assigned_three_unassigned() -> sp_io::TestExternalities {
 	])
 }
 
+pub(crate) fn two_assigned_contributions_less_than_vesting() -> sp_io::TestExternalities {
+	genesis(vec![
+		// validators
+		([1u8; 32].into(), Some(1), 5),
+		([2u8; 32].into(), Some(2), 5),
+	])
+}
+
 pub(crate) fn events() -> Vec<super::Event<Test>> {
 	System::events()
 		.into_iter()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -308,7 +308,7 @@ fn initialize_new_addresses_with_batch() {
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 1,
+					error: 2,
 					message: None,
 				},
 			),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -245,14 +245,17 @@ fn initialize_new_addresses() {
 			],
 			1,
 			0,
-			4
+			5
 		));
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
-			vec![([6u8; 32].into(), Some(6), 500)],
+			vec![
+				([6u8; 32].into(), Some(6), 500),
+				([7u8; 32].into(), Some(7), 1)
+			],
 			1,
 			3,
-			4
+			5
 		));
 		assert_noop!(
 			Crowdloan::initialize_reward_vec(
@@ -265,11 +268,10 @@ fn initialize_new_addresses() {
 			Error::<Test>::CurrentLeasePeriodAlreadyInitialized
 		);
 		assert_eq!(Crowdloan::next_initialization(), 20);
-		let expected = vec![crate::Event::ErrorWhileInitializing(
-			[1u8; 32],
-			Some(1),
-			500,
-		)];
+		let expected = vec![
+			crate::Event::AlreadyInitialized([1u8; 32], Some(1), 500),
+			crate::Event::NotEnoughContribution([7u8; 32], Some(7), 1),
+		];
 		assert_eq!(events(), expected);
 	});
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -317,3 +317,19 @@ fn initialize_new_addresses_with_batch() {
 		assert_eq!(batch_events(), expected);
 	});
 }
+
+#[test]
+fn if_contribution_less_than_vesting_minimum_payable_should_be_one() {
+	two_assigned_contributions_less_than_vesting().execute_with(|| {
+		roll_to(6);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
+
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 6u64);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 5);
+		roll_to(6);
+		assert_noop!(
+			Crowdloan::show_me_the_money(Origin::signed(1)),
+			Error::<Test>::RewardsAlreadyClaimed
+		);
+	});
+}


### PR DESCRIPTION
This PR handles the case in which the contribution is less than the vesting period, in which case we were not rewarding the contributor. I know we can control this with the minimum amount, but for the moment I just made a quick check. I set the minimum payout to 1, but I am open to suggestions since this is unlikely to happen

I also added a minimumContribution check both when initializing the reward vec and when paying. For us one of those should be enough but I could not decide on one (Checking this when initializing the reward vec allows us to save on storage, while checking it when paying allows us to have a better record of who contributed, even if under minimumContribution)