### PR TITLE
Transfer instead of mint and initialization payment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus"
 nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "rococo-v1" }
 
 [dev-dependencies]
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "r
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+
 
 
 [features]
@@ -37,5 +39,6 @@ std = [
     "sp-std/std",
     "sp-io/std",
     "cumulus-pallet-parachain-system/std",
+    "cumulus-primitives-core/std",
     "nimbus-primitives/std"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus"
 nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "rococo-v1" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "rococo-v1", default-features = false }
 
 [dev-dependencies]
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ version = '0.6.0'
 description = "Reward citizens who participated in a crowdloan to acquire a parachain slot o nthe backing relay chain."
 
 [dependencies]
-parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.101", optional = true, features = ["derive"] }
+parity-scale-codec = { version = "2.1.1", default-features = false}
+serde = { version = "1.0.101", optional = true, features = ["derive"], default-features = false }
 log = { version = "0.4", default-features = false }
 
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
@@ -18,6 +18,8 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 
 
 [features]
@@ -33,5 +35,7 @@ std = [
     "serde",
     "log/std",
     "sp-std/std",
-    "sp-io/std"
+    "sp-io/std",
+    "cumulus-pallet-parachain-system/std",
+    "nimbus-primitives/std"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "ro
 cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 
 
 
@@ -40,5 +42,7 @@ std = [
     "sp-io/std",
     "cumulus-pallet-parachain-system/std",
     "cumulus-primitives-core/std",
-    "nimbus-primitives/std"
+    "nimbus-primitives/std",
+    "cumulus-primitives-parachain-inherent/std",
+    "cumulus-test-relay-sproof-builder/std"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,5 @@ std = [
     "cumulus-primitives-core/std",
     "nimbus-primitives/std",
     "cumulus-primitives-parachain-inherent/std",
+    "polkadot-primitives/std"
     ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus"
 nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
+
+[dev-dependencies]
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
 
 [features]
@@ -43,5 +45,4 @@ std = [
     "cumulus-primitives-core/std",
     "nimbus-primitives/std",
     "cumulus-primitives-parachain-inherent/std",
-    "cumulus-test-relay-sproof-builder/std"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ sp-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, optional = true }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 
 [features]
 default = ["std"]
@@ -45,4 +45,4 @@ std = [
     "cumulus-primitives-core/std",
     "nimbus-primitives/std",
     "cumulus-primitives-parachain-inherent/std",
-]
+    ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,12 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-
-
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, optional = true }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, rev = "9f16c89" }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,12 +70,14 @@ mod tests;
 #[pallet]
 pub mod pallet {
 
+	use frame_support::traits::ExistenceRequirement::KeepAlive;
 	use frame_support::{dispatch::fmt::Debug, pallet_prelude::*, traits::Currency};
 	use frame_system::pallet_prelude::*;
 	use sp_core::crypto::AccountId32;
 	use sp_runtime::traits::{Saturating, Verify};
 	use sp_runtime::{MultiSignature, SaturatedConversion};
 	use sp_std::{convert::TryInto, vec::Vec};
+
 	/// The Author Filter pallet
 	#[pallet::pallet]
 	pub struct Pallet<T>(PhantomData<T>);
@@ -87,6 +89,8 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Checker for the reward vec, is it initalized already?
 		type Initialized: Get<bool>;
+		/// The account from which payments will be performed
+		type PalletAccountId: Get<Self::AccountId>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
 		type RewardCurrency: Currency<Self::AccountId>;
 		// TODO What trait bounds do I need here? I think concretely we would
@@ -229,7 +233,14 @@ pub mod pallet {
 			// TODO where are these reward funds coming from? Currently I'm just minting them right here.
 			// 1. We could have an associated type to absorb the imbalance.
 			// 2. We could have this pallet control a pot of funds, and initialize it at genesis.
-			T::RewardCurrency::deposit_creating(&payee, payable_amount);
+			T::RewardCurrency::transfer(
+				&T::PalletAccountId::get(),
+				&payee,
+				payable_amount,
+				KeepAlive,
+			)?;
+
+			//	T::RewardCurrency::deposit_creating(&payee, payable_amount);
 
 			// Emit event
 			Self::deposit_event(Event::RewardsPaid(payee, payable_amount));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,7 @@ pub mod pallet {
 						relay_account.clone(),
 						native_account.clone(),
 						*contribution,
-						));
+					));
 					continue;
 				}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,6 @@ pub mod pallet {
 			AccountsPayable::<T>::insert(&payee, &info);
 
 			// This pallet controls an amount of funds and transfers them to each of the contributors
-			//TODO: contributors should have the balance locked for tranfers but not for democracy
 			T::RewardCurrency::transfer(
 				&PALLET_ID.into_account(),
 				&payee,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Checker for the reward vec, is it initalized already?
 		type Initialized: Get<bool>;
-		/// Commission due to collators, set at genesis
+		/// Percentage to be payed at initialization
 		type InitializationPayment: Get<Perbill>;
 		/// The account from which payments will be performed
 		type PalletAccountId: Get<Self::AccountId>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,20 @@ pub mod pallet {
 			);
 
 			// Upon error this should check the relay chain state in this case
-			let reward_info = UnassociatedContributions::<T>::get(&relay_account)
+			let mut reward_info = UnassociatedContributions::<T>::get(&relay_account)
 				.ok_or(Error::<T>::NoAssociatedClaim)?;
+
+			// Make the first payment
+			let first_payment = T::InitializationPayment::get() * reward_info.total_reward;
+
+			T::RewardCurrency::transfer(
+				&T::PalletAccountId::get(),
+				&reward_account,
+				first_payment,
+				KeepAlive,
+			)?;
+
+			reward_info.claimed_reward = first_payment;
 
 			// Insert on payable
 			AccountsPayable::<T>::insert(&reward_account, &reward_info);
@@ -203,7 +215,10 @@ pub mod pallet {
 			);
 			let now = frame_system::Pallet::<T>::block_number();
 
-			let payable_per_block = info.total_reward
+			// Substract the first payment from the vested amount
+			let first_paid = T::InitializationPayment::get() * info.total_reward;
+
+			let payable_per_block = (info.total_reward - first_paid)
 				/ T::VestingPeriod::get()
 					.saturated_into::<u128>()
 					.try_into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,8 @@ pub mod pallet {
 		/// User trying to associate a native identity with a relay chain identity for posterior
 		/// reward claiming provided an already associated relay chain identity
 		AlreadyAssociated,
+		/// The contribution is not high enough to be eligible for rewards
+		ContributionNotHighEnough,
 		/// User trying to associate a native identity with a relay chain identity for posterior
 		/// reward claiming provided a wrong signature
 		InvalidClaimSignature,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,6 @@ pub mod pallet {
 	/// Configuration trait of this pallet.
 	#[pallet::config]
 	pub trait Config: cumulus_pallet_parachain_system::Config + frame_system::Config {
-		/// Default number of blocks per round at genesis
-		type DefaultBlocksPerRound: Get<u32>;
 		/// The period after which the contribution storage can be initialized again
 		type MinimumContribution: Get<BalanceOf<Self>>;
 		/// The overarching event type
@@ -386,6 +384,13 @@ pub mod pallet {
 		}
 	}
 
+	impl<T: Config> Pallet<T> {
+		/// The account ID that holds the Crowdloan's funds
+		pub fn account_id() -> T::AccountId {
+			PALLET_ID.into_account()
+		}
+	}
+
 	impl<T: cumulus_pallet_parachain_system::Config> SlotBeacon for RelayChainBeacon<T> {
 		fn slot() -> u32 {
 			cumulus_pallet_parachain_system::Module::<T>::validation_data()
@@ -447,9 +452,6 @@ pub mod pallet {
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
 			T::RewardCurrency::make_free_balance_be(&Pallet::<T>::account_id(), self.funded_amount);
-			let round: RoundInfo<T::BlockNumber> =
-				RoundInfo::new(1u32, 0u32.into(), T::DefaultBlocksPerRound::get());
-			<Round<T>>::put(round);
 		}
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,7 @@ pub mod pallet {
 						relay_account.clone(),
 						native_account.clone(),
 						*contribution,
-					));
+						));
 					continue;
 				}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ pub mod pallet {
 			proof: MultiSignature,
 		) -> DispatchResultWithPostInfo {
 			ensure_signed(origin)?;
+			let _ = RelayChainBeacon::<T>::slot();
 			// Check the proof:
 			// 1. Is signed by an actual unassociated contributor
 			// 2. Signs a valid native identity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,11 @@ mod tests;
 pub mod pallet {
 
 	use frame_support::traits::ExistenceRequirement::KeepAlive;
-	use frame_support::{dispatch::fmt::Debug, pallet_prelude::*, traits::Currency};
+	use frame_support::{dispatch::fmt::Debug, pallet_prelude::*, traits::Currency, PalletId};
 	use frame_system::pallet_prelude::*;
 	use nimbus_primitives::SlotBeacon;
 	use sp_core::crypto::AccountId32;
+	use sp_runtime::traits::AccountIdConversion;
 	use sp_runtime::traits::{Saturating, Verify};
 	use sp_runtime::{MultiSignature, Perbill, SaturatedConversion};
 	use sp_std::{convert::TryInto, vec::Vec};
@@ -82,6 +83,8 @@ pub mod pallet {
 	/// The Author Filter pallet
 	#[pallet::pallet]
 	pub struct Pallet<T>(PhantomData<T>);
+
+	pub const PALLET_ID: PalletId = PalletId(*b"Crowdloa");
 
 	pub struct RelayChainBeacon<T>(PhantomData<T>);
 
@@ -98,8 +101,6 @@ pub mod pallet {
 		type Initialized: Get<bool>;
 		/// Percentage to be payed at initialization
 		type InitializationPayment: Get<Perbill>;
-		/// The account from which payments will be performed
-		type PalletAccountId: Get<Self::AccountId>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
 		type RewardCurrency: Currency<Self::AccountId>;
 		// TODO What trait bounds do I need here? I think concretely we would
@@ -182,7 +183,7 @@ pub mod pallet {
 			let first_payment = T::InitializationPayment::get() * reward_info.total_reward;
 
 			T::RewardCurrency::transfer(
-				&T::PalletAccountId::get(),
+				&PALLET_ID.into_account(),
 				&reward_account,
 				first_payment,
 				KeepAlive,
@@ -264,7 +265,7 @@ pub mod pallet {
 			// 1. We could have an associated type to absorb the imbalance.
 			// 2. We could have this pallet control a pot of funds, and initialize it at genesis.
 			T::RewardCurrency::transfer(
-				&T::PalletAccountId::get(),
+				&PALLET_ID.into_account(),
 				&payee,
 				payable_amount,
 				KeepAlive,
@@ -351,7 +352,7 @@ pub mod pallet {
 				let initial_payment = if let Some(native_account) = native_account {
 					let first_payment = T::InitializationPayment::get() * total_payment;
 					T::RewardCurrency::transfer(
-						&T::PalletAccountId::get(),
+						&PALLET_ID.into_account(),
 						&native_account,
 						first_payment,
 						KeepAlive,
@@ -412,6 +413,44 @@ pub mod pallet {
 		RewardVecAlreadyInitialized,
 		/// Invalid conversion while calculating payable amount
 		WrongConversionU128ToBalance,
+	}
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		/// Contributions that have a native account id associated already.
+		pub associated: Vec<(T::RelayChainAccountId, T::AccountId, u32)>,
+		/// Contributions that will need a native account id to be associated through an extrinsic.
+		pub unassociated: Vec<(T::RelayChainAccountId, u32)>,
+		/// The ratio of (reward tokens to be paid) / (relay chain funds contributed)
+		/// This is dead stupid simple using a u32. So the reward amount has to be an integer
+		/// multiple of the contribution amount. A better fixed-ratio solution would be
+		/// https://crates.parity.io/sp_arithmetic/fixed_point/struct.FixedU128.html
+		/// We could also do something fancy and non-linear if the need arises.
+		pub reward_ratio: u32,
+		/// We could also do something fancy and non-linear if the need arises.
+		pub funded_amount: BalanceOf<T>,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				associated: Vec::new(),
+				unassociated: Vec::new(),
+				reward_ratio: 1,
+				funded_amount: 1u32.into(),
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			T::RewardCurrency::make_free_balance_be(&Pallet::<T>::account_id(), self.funded_amount);
+			let round: RoundInfo<T::BlockNumber> =
+				RoundInfo::new(1u32, 0u32.into(), T::DefaultBlocksPerRound::get());
+			<Round<T>>::put(round);
+		}
 	}
 
 	#[pallet::storage]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -38,7 +38,6 @@ use sp_runtime::{
 };
 use sp_std::convert::{From, TryInto};
 
-pub type AccountId = u64;
 pub type Balance = u128;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -141,33 +140,16 @@ impl pallet_utility::Config for Test {
 	type WeightInfo = ();
 }
 
-fn genesis(contributions: Vec<([u8; 32], Option<AccountId>, u32)>) -> sp_io::TestExternalities {
+fn genesis(funded_amount: Balance) -> sp_io::TestExternalities {
 	let mut storage = frame_system::GenesisConfig::default()
 		.build_storage::<Test>()
 		.unwrap();
-	pallet_crowdloan_rewards::GenesisConfig::<Test> {
-		associated: vec![],
-		unassociated: vec![],
-		reward_ratio: 0,
-		funded_amount: 100000u32.into(),
-	}
-	.assimilate_storage(&mut storage)
-	.expect("Pallet balances storage can be assimilated");
+	pallet_crowdloan_rewards::GenesisConfig::<Test> { funded_amount }
+		.assimilate_storage(&mut storage)
+		.expect("Pallet balances storage can be assimilated");
 
 	let mut ext = sp_io::TestExternalities::from(storage);
-	ext.execute_with(|| {
-		if contributions.len() > 0 {
-			Crowdloan::initialize_reward_vec(
-				Origin::root(),
-				contributions.clone(),
-				1,
-				0,
-				contributions.len() as u32,
-			)
-			.unwrap();
-		}
-		System::set_block_number(1)
-	});
+	ext.execute_with(|| System::set_block_number(1));
 	ext
 }
 
@@ -189,7 +171,7 @@ pub(crate) fn get_ed25519_pairs(num: u32) -> Vec<ed25519::Pair> {
 }
 
 pub(crate) fn empty() -> sp_io::TestExternalities {
-	genesis(vec![])
+	genesis(100000u32.into())
 }
 
 pub(crate) fn events() -> Vec<super::Event<Test>> {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -20,11 +20,10 @@ use cumulus_primitives_core::relay_chain::BlockNumber as RelayChainBlockNumber;
 use cumulus_primitives_core::PersistedValidationData;
 use cumulus_primitives_parachain_inherent::ParachainInherentData;
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
-use frame_support::inherent::InherentData;
 use frame_support::{
 	construct_runtime,
 	dispatch::UnfilteredDispatchable,
-	inherent::ProvideInherent,
+	inherent::{InherentData, ProvideInherent},
 	parameter_types,
 	traits::{GenesisBuild, OnFinalize, OnInitialize},
 };

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -161,18 +161,6 @@ pub(crate) fn get_ed25519_pairs(num: u32) -> Vec<ed25519::Pair> {
 	pairs
 }
 
-pub(crate) fn two_assigned_three_unassigned() -> sp_io::TestExternalities {
-	let pairs = get_ed25519_pairs(3);
-	genesis(vec![
-		// validators
-		([1u8; 32].into(), Some(1), 500),
-		([2u8; 32].into(), Some(2), 500),
-		(pairs[0].public().into(), None, 500),
-		(pairs[1].public().into(), None, 500),
-		(pairs[2].public().into(), None, 500),
-	])
-}
-
 pub(crate) fn empty() -> sp_io::TestExternalities {
 	genesis(vec![])
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -22,6 +22,7 @@ use sp_io;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	Perbill,
 };
 use sp_std::convert::{From, TryInto};
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -94,12 +94,12 @@ parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
 	pub const TestLeasePeriod: u64 = 10;
 	pub const TestDefaultNextInitialization: u64 = 0;
+	pub const TestInitialized: bool = false;
 }
 
 impl Config for Test {
 	type Event = Event;
-	type LeasePeriod = TestLeasePeriod;
-	type DefaultNextInitialization = TestDefaultNextInitialization;
+	type Initialized = TestInitialized;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;
@@ -118,14 +118,16 @@ fn genesis(contributions: Vec<([u8; 32], Option<AccountId>, u32)>) -> sp_io::Tes
 
 	let mut ext = sp_io::TestExternalities::from(storage);
 	ext.execute_with(|| {
-		Crowdloan::initialize_reward_vec(
-			Origin::root(),
-			contributions.clone(),
-			1,
-			0,
-			contributions.len() as u32,
-		)
-		.unwrap();
+		if contributions.len() > 0 {
+			Crowdloan::initialize_reward_vec(
+				Origin::root(),
+				contributions.clone(),
+				1,
+				0,
+				contributions.len() as u32,
+			)
+			.unwrap();
+		}
 		System::set_block_number(1)
 	});
 	ext
@@ -158,6 +160,10 @@ pub(crate) fn two_assigned_three_unassigned() -> sp_io::TestExternalities {
 		(pairs[1].public().into(), None, 500),
 		(pairs[2].public().into(), None, 500),
 	])
+}
+
+pub(crate) fn empty() -> sp_io::TestExternalities {
+	genesis(vec![])
 }
 
 pub(crate) fn events() -> Vec<super::Event<Test>> {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -227,7 +227,7 @@ pub(crate) fn roll_to(n: u64) {
 		let (relay_parent_storage_root, relay_chain_state) =
 			sproof_builder.into_state_root_and_proof();
 		let vfp = PersistedValidationData {
-			relay_parent_number: n as RelayChainBlockNumber,
+			relay_parent_number: (System::block_number() + 1u64) as RelayChainBlockNumber,
 			relay_parent_storage_root,
 			..Default::default()
 		};
@@ -248,6 +248,13 @@ pub(crate) fn roll_to(n: u64) {
 			inherent_data
 		};
 
+		ParachainSystem::on_initialize(System::block_number());
+		ParachainSystem::create_inherent(&inherent_data)
+			.expect("got an inherent")
+			.dispatch_bypass_filter(RawOrigin::None.into())
+			.expect("dispatch succeeded");
+		ParachainSystem::on_finalize(System::block_number());
+
 		Crowdloan::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());
 		System::on_finalize(System::block_number());
@@ -255,11 +262,5 @@ pub(crate) fn roll_to(n: u64) {
 		System::on_initialize(System::block_number());
 		Balances::on_initialize(System::block_number());
 		Crowdloan::on_initialize(System::block_number());
-		ParachainSystem::on_initialize(n);
-		ParachainSystem::create_inherent(&inherent_data)
-			.expect("got an inherent")
-			.dispatch_bypass_filter(RawOrigin::None.into())
-			.expect("dispatch succeeded");
-		ParachainSystem::on_finalize(n);
 	}
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -119,7 +119,8 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
-	pub const TestPalletAccountId: AccountId = 100;
+	pub const TestMinimumContribution: u128 = 0;
+	pub const TestDefaultBlocksPerRound: u32 = 500;
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 }
@@ -128,7 +129,6 @@ impl Config for Test {
 	type Event = Event;
 	type Initialized = TestInitialized;
 	type InitializationPayment = TestInitializationPayment;
-	type PalletAccountId = TestPalletAccountId;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;
@@ -145,14 +145,14 @@ fn genesis(contributions: Vec<([u8; 32], Option<AccountId>, u32)>) -> sp_io::Tes
 	let mut storage = frame_system::GenesisConfig::default()
 		.build_storage::<Test>()
 		.unwrap();
-
-	// AccountId paying the rewards
-	let balances_vec = vec![(TestPalletAccountId::get(), 1000000)];
-	pallet_balances::GenesisConfig::<Test> {
-		balances: balances_vec,
+	pallet_crowdloan_rewards::GenesisConfig::<Test> {
+		associated: vec![],
+		unassociated: vec![],
+		reward_ratio: 0,
+		funded_amount: 100000u32.into(),
 	}
 	.assimilate_storage(&mut storage)
-	.unwrap();
+	.expect("Pallet balances storage can be assimilated");
 
 	let mut ext = sp_io::TestExternalities::from(storage);
 	ext.execute_with(|| {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -41,9 +41,24 @@ construct_runtime!(
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		Crowdloan: pallet_crowdloan_rewards::{Pallet, Call, Storage, Event<T>},
+		ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Storage, Inherent, Event<T>},
 		Utility: pallet_utility::{Pallet, Call, Storage, Event},
 	}
 );
+
+parameter_types! {
+	pub ParachainId: cumulus_primitives_core::ParaId = 100.into();
+}
+
+impl cumulus_pallet_parachain_system::Config for Test {
+	type SelfParaId = ParachainId;
+	type Event = Event;
+	type OnValidationData = ();
+	type DownwardMessageHandlers = ();
+	type OutboundXcmpMessageSource = ();
+	type XcmpMessageHandler = ();
+	type ReservedXcmpWeight = ();
+}
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -72,7 +87,7 @@ impl frame_system::Config for Test {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
-	type OnSetCode = ();
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -94,11 +94,13 @@ parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
 	pub const TestPalletAccountId: AccountId = 100;
 	pub const TestInitialized: bool = false;
+	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 }
 
 impl Config for Test {
 	type Event = Event;
 	type Initialized = TestInitialized;
+	type InitializationPayment = TestInitializationPayment;
 	type PalletAccountId = TestPalletAccountId;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -92,14 +92,14 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
-	pub const TestLeasePeriod: u64 = 10;
-	pub const TestDefaultNextInitialization: u64 = 0;
+	pub const TestPalletAccountId: AccountId = 100;
 	pub const TestInitialized: bool = false;
 }
 
 impl Config for Test {
 	type Event = Event;
 	type Initialized = TestInitialized;
+	type PalletAccountId = TestPalletAccountId;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;
@@ -112,9 +112,17 @@ impl pallet_utility::Config for Test {
 }
 
 fn genesis(contributions: Vec<([u8; 32], Option<AccountId>, u32)>) -> sp_io::TestExternalities {
-	let storage = frame_system::GenesisConfig::default()
+	let mut storage = frame_system::GenesisConfig::default()
 		.build_storage::<Test>()
 		.unwrap();
+
+	// AccountId paying the rewards
+	let balances_vec = vec![(TestPalletAccountId::get(), 1000000)];
+	pallet_balances::GenesisConfig::<Test> {
+		balances: balances_vec,
+	}
+	.assimilate_storage(&mut storage)
+	.unwrap();
 
 	let mut ext = sp_io::TestExternalities::from(storage);
 	ext.execute_with(|| {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -16,14 +16,19 @@
 
 //! Test utilities
 use crate::{self as pallet_crowdloan_rewards, Config};
-use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{GenesisBuild, OnFinalize, OnInitialize},
-	inherent::{ProvideInherent},
-	dispatch::UnfilteredDispatchable,
-};
-use cumulus_primitives_core::{relay_chain::BlockNumber as RelayChainBlockNumber};
+use cumulus_primitives_core::relay_chain::BlockNumber as RelayChainBlockNumber;
+use cumulus_primitives_core::PersistedValidationData;
+use cumulus_primitives_parachain_inherent::ParachainInherentData;
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
+use frame_support::inherent::InherentData;
+use frame_support::{
+	construct_runtime,
+	dispatch::UnfilteredDispatchable,
+	inherent::ProvideInherent,
+	parameter_types,
+	traits::{GenesisBuild, OnFinalize, OnInitialize},
+};
+use frame_system::RawOrigin;
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
 use sp_runtime::{
@@ -32,10 +37,6 @@ use sp_runtime::{
 	Perbill,
 };
 use sp_std::convert::{From, TryInto};
-use frame_support::inherent::InherentData;
-use frame_system::RawOrigin;
-use cumulus_primitives_parachain_inherent::ParachainInherentData;
-use cumulus_primitives_core::PersistedValidationData;
 
 pub type AccountId = u64;
 pub type Balance = u128;
@@ -120,7 +121,6 @@ impl pallet_balances::Config for Test {
 parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
 	pub const TestMinimumContribution: u128 = 0;
-	pub const TestDefaultBlocksPerRound: u32 = 500;
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 }
@@ -129,6 +129,7 @@ impl Config for Test {
 	type Event = Event;
 	type Initialized = TestInitialized;
 	type InitializationPayment = TestInitializationPayment;
+	type MinimumContribution = TestMinimumContribution;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;
@@ -139,7 +140,6 @@ impl pallet_utility::Config for Test {
 	type Call = Call;
 	type WeightInfo = ();
 }
-
 
 fn genesis(contributions: Vec<([u8; 32], Option<AccountId>, u32)>) -> sp_io::TestExternalities {
 	let mut storage = frame_system::GenesisConfig::default()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -391,7 +391,7 @@ fn initialize_new_addresses_with_batch() {
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 4,
+					error: 5,
 					message: None,
 				},
 			),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -361,7 +361,7 @@ fn initialize_new_addresses_with_batch() {
 	empty().execute_with(|| {
 		// This time should succeed trully
 		roll_to(10);
-		assert_ok!(mock::Call::Utility(UtilityCall::batch(vec![
+		assert_ok!(mock::Call::Utility(UtilityCall::batch_all(vec![
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
 				vec![([4u8; 32].into(), Some(3), 500)],
 				1,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -107,7 +107,7 @@ fn paying_works() {
 		roll_to(4);
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 4u64);
-		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 248);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 300);
 		assert_noop!(
 			Crowdloan::show_me_the_money(Origin::signed(3)),
 			Error::<Test>::NoAssociatedClaim
@@ -115,15 +115,15 @@ fn paying_works() {
 		roll_to(5);
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 5u64);
-		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 310);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 350);
 		roll_to(6);
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 6u64);
-		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 372);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 400);
 		roll_to(7);
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 7u64);
-		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 434);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 450);
 		roll_to(230);
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 500);
@@ -134,11 +134,11 @@ fn paying_works() {
 		);
 
 		let expected = vec![
-			crate::Event::RewardsPaid(1, 248),
-			crate::Event::RewardsPaid(1, 62),
-			crate::Event::RewardsPaid(1, 62),
-			crate::Event::RewardsPaid(1, 62),
-			crate::Event::RewardsPaid(1, 66),
+			crate::Event::RewardsPaid(1, 200),
+			crate::Event::RewardsPaid(1, 50),
+			crate::Event::RewardsPaid(1, 50),
+			crate::Event::RewardsPaid(1, 50),
+			crate::Event::RewardsPaid(1, 50),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -162,7 +162,7 @@ fn paying_late_joiner_works() {
 		assert_eq!(Crowdloan::accounts_payable(&3).unwrap().claimed_reward, 500);
 		let expected = vec![
 			crate::Event::NativeIdentityAssociated(pairs[0].public().into(), 3, 500),
-			crate::Event::RewardsPaid(3, 500),
+			crate::Event::RewardsPaid(3, 400),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -179,15 +179,15 @@ fn update_address_works() {
 		);
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().last_paid, 4u64);
-		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 248);
+		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 300);
 		roll_to(6);
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(8)));
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().last_paid, 6u64);
-		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 372);
+		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 400);
 		let expected = vec![
-			crate::Event::RewardsPaid(1, 248),
+			crate::Event::RewardsPaid(1, 200),
 			crate::Event::RewardAddressUpdated(1, 8),
-			crate::Event::RewardsPaid(8, 124),
+			crate::Event::RewardsPaid(8, 100),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -201,7 +201,7 @@ fn update_address_with_existing_address_works() {
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(2)));
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().last_paid, 4u64);
-		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 496);
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 600);
 		assert_noop!(
 			Crowdloan::show_me_the_money(Origin::signed(1)),
 			Error::<Test>::NoAssociatedClaim
@@ -209,12 +209,12 @@ fn update_address_with_existing_address_works() {
 		roll_to(6);
 		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(2)));
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().last_paid, 6u64);
-		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 746);
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 800);
 		let expected = vec![
-			crate::Event::RewardsPaid(1, 248),
-			crate::Event::RewardsPaid(2, 248),
+			crate::Event::RewardsPaid(1, 200),
+			crate::Event::RewardsPaid(2, 200),
 			crate::Event::RewardAddressUpdated(1, 2),
-			crate::Event::RewardsPaid(2, 250),
+			crate::Event::RewardsPaid(2, 200),
 		];
 		assert_eq!(events(), expected);
 	});

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -232,59 +232,14 @@ fn initialize_new_addresses() {
 				0,
 				1
 			),
-			Error::<Test>::CurrentLeasePeriodAlreadyInitialized
+			Error::<Test>::RewardVecAlreadyInitialized,
 		);
-		assert_eq!(Crowdloan::next_initialization(), 10);
-		roll_to(10);
-		assert_ok!(Crowdloan::initialize_reward_vec(
-			Origin::root(),
-			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([4u8; 32].into(), Some(4), 500),
-				([5u8; 32].into(), None, 500)
-			],
-			1,
-			0,
-			4
-		));
-		assert_ok!(Crowdloan::initialize_reward_vec(
-			Origin::root(),
-			vec![([6u8; 32].into(), Some(6), 500)],
-			1,
-			3,
-			4
-		));
-		assert_noop!(
-			Crowdloan::initialize_reward_vec(
-				Origin::root(),
-				vec![([7u8; 32].into(), Some(7), 500)],
-				1,
-				0,
-				1
-			),
-			Error::<Test>::CurrentLeasePeriodAlreadyInitialized
-		);
-		assert_eq!(Crowdloan::next_initialization(), 20);
-		let expected = vec![crate::Event::ErrorWhileInitializing(
-			[1u8; 32],
-			Some(1),
-			500,
-		)];
-		assert_eq!(events(), expected);
 	});
 }
 
 #[test]
 fn initialize_new_addresses_with_batch() {
-	two_assigned_three_unassigned().execute_with(|| {
-		// Batch calls always succeed. We just need to check the inner event
-		assert_ok!(
-			mock::Call::Utility(UtilityCall::batch(vec![mock::Call::Crowdloan(
-				crate::Call::initialize_reward_vec(vec![([4u8; 32].into(), Some(3), 500)], 1, 0, 1)
-			)]))
-			.dispatch(Origin::root())
-		);
-
+	empty().execute_with(|| {
 		// This time should succeed trully
 		roll_to(10);
 		assert_ok!(mock::Call::Utility(UtilityCall::batch(vec![
@@ -303,16 +258,24 @@ fn initialize_new_addresses_with_batch() {
 		]))
 		.dispatch(Origin::root()));
 
+		// Batch calls always succeed. We just need to check the inner event
+		assert_ok!(
+			mock::Call::Utility(UtilityCall::batch(vec![mock::Call::Crowdloan(
+				crate::Call::initialize_reward_vec(vec![([4u8; 32].into(), Some(3), 500)], 1, 0, 1)
+			)]))
+			.dispatch(Origin::root())
+		);
+
 		let expected = vec![
+			pallet_utility::Event::BatchCompleted,
 			pallet_utility::Event::BatchInterrupted(
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 1,
+					error: 4,
 					message: None,
 				},
 			),
-			pallet_utility::Event::BatchCompleted,
 		];
 		assert_eq!(batch_events(), expected);
 	});


### PR DESCRIPTION
This PR makes several changes:

- Removes next initialization related functions and variables since we will only have one initialization
- The payment changes from Mint to Transfer: A pallet-associated account is in charge of transferring funds
- We include a percentage that is payed upon initialization. The vested amount is total_reward - first_payment, and it is divided in vesting_periods
- The vesting periods are counted with respect to the relay chain height. We gather the relay chain height at the first block of the parachain, and compare against this height to count the amount vested
- A minimum contribution check has been added at initialization