### PR TITLE
Free claim plus remove floating point arithmetic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cu
 
 [dev-dependencies]
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"] }
+account = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "c51a2b79" }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus"
 nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "rococo-v1", default-features = false }
 
 [dev-dependencies]
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
@@ -46,5 +45,4 @@ std = [
     "cumulus-primitives-core/std",
     "nimbus-primitives/std",
     "cumulus-primitives-parachain-inherent/std",
-    "polkadot-primitives/std"
     ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,6 @@ cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cu
 
 [dev-dependencies]
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"] }
-account = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "c51a2b79" }
-sha3 = { version = "0.8", default-features = false }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cu
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"] }
 account = { git = "https://github.com/purestake/moonbeam", default-features = false, rev = "c51a2b79" }
+sha3 = { version = "0.8", default-features = false }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@ pub mod pallet {
 		PalletId,
 	};
 	use frame_system::pallet_prelude::*;
-	use polkadot_primitives::v0::Balance as RelayBalance;
 	use sp_core::crypto::AccountId32;
 	use sp_runtime::traits::{AccountIdConversion, Saturating, Verify};
 	use sp_runtime::{MultiSignature, Perbill, SaturatedConversion};
@@ -101,7 +100,7 @@ pub mod pallet {
 		/// Percentage to be payed at initialization
 		type InitializationPayment: Get<Perbill>;
 		/// The minimum contribution to which rewards will be paid.
-		type MinimumContribution: Get<BalanceOf<Self>>;
+		type MinimumReward: Get<BalanceOf<Self>>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
 		type RewardCurrency: Currency<Self::AccountId>;
 		// TODO What trait bounds do I need here? I think concretely we would
@@ -334,8 +333,7 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn initialize_reward_vec(
 			origin: OriginFor<T>,
-			contributions: Vec<(T::RelayChainAccountId, Option<T::AccountId>, RelayBalance)>,
-			reward_ratio: BalanceOf<T>,
+			rewards: Vec<(T::RelayChainAccountId, Option<T::AccountId>, BalanceOf<T>)>,
 			index: u32,
 			limit: u32,
 		) -> DispatchResultWithPostInfo {
@@ -347,7 +345,7 @@ pub mod pallet {
 				Error::<T>::RewardVecAlreadyInitialized
 			);
 
-			for (relay_account, native_account, contribution) in &contributions {
+			for (relay_account, native_account, reward) in &rewards {
 				if ClaimedRelayChainIds::<T>::get(&relay_account).is_some()
 					|| UnassociatedContributions::<T>::get(&relay_account).is_some()
 				{
@@ -356,32 +354,25 @@ pub mod pallet {
 					Self::deposit_event(Event::InitializedAlreadyInitializedAccount(
 						relay_account.clone(),
 						native_account.clone(),
-						*contribution,
+						*reward,
 					));
 					continue;
 				}
 
-				let contribution_as_balance: BalanceOf<T> = (*contribution)
-					.try_into()
-					.ok()
-					.ok_or(Error::<T>::WrongConversionU128ToBalance)?;
-
-				let total_payment = contribution_as_balance.saturating_mul(reward_ratio);
-
-				if total_payment < T::MinimumContribution::get() {
+				if *reward < T::MinimumReward::get() {
 					// Dont fail as this is supposed to be called with batch calls and we
 					// dont want to stall the rest of the contributions
 					Self::deposit_event(Event::InitializedAccountWithNotEnoughContribution(
 						relay_account.clone(),
 						native_account.clone(),
-						*contribution,
+						*reward,
 					));
 					continue;
 				}
 
 				// If we have a native_account, we make the payment
 				let initial_payment = if let Some(native_account) = native_account {
-					let first_payment = T::InitializationPayment::get() * total_payment;
+					let first_payment = T::InitializationPayment::get() * (*reward);
 					T::RewardCurrency::transfer(
 						&PALLET_ID.into_account(),
 						&native_account,
@@ -399,7 +390,7 @@ pub mod pallet {
 
 				// We need to calculate the vesting based on the relay block number
 				let reward_info = RewardInfo {
-					total_reward: total_payment,
+					total_reward: *reward,
 					claimed_reward: initial_payment,
 					last_paid: <InitRelayBlock<T>>::get().into(),
 				};
@@ -411,7 +402,7 @@ pub mod pallet {
 					UnassociatedContributions::<T>::insert(relay_account, reward_info);
 				}
 			}
-			if index + contributions.len() as u32 == limit {
+			if index + rewards.len() as u32 == limit {
 				<Initialized<T>>::put(true);
 			}
 			Ok(Default::default())
@@ -431,7 +422,7 @@ pub mod pallet {
 		/// reward claiming provided an already associated relay chain identity
 		AlreadyAssociated,
 		/// The contribution is not high enough to be eligible for rewards
-		ContributionNotHighEnough,
+		RewardNotHighEnough,
 		/// User trying to associate a native identity with a relay chain identity for posterior
 		/// reward claiming provided a wrong signature
 		InvalidClaimSignature,
@@ -509,13 +500,13 @@ pub mod pallet {
 		InitializedAlreadyInitializedAccount(
 			T::RelayChainAccountId,
 			Option<T::AccountId>,
-			RelayBalance,
+			BalanceOf<T>,
 		),
 		/// When initializing the reward vec an already initialized account was found
 		InitializedAccountWithNotEnoughContribution(
 			T::RelayChainAccountId,
 			Option<T::AccountId>,
-			RelayBalance,
+			BalanceOf<T>,
 		),
 	}
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -118,7 +118,7 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
 	pub const TestVestingPeriod: u64 = 8;
-	pub const TestMinimumContribution: u128 = 0;
+	pub const TestMinimumReward: u128 = 0;
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 }
@@ -127,7 +127,7 @@ impl Config for Test {
 	type Event = Event;
 	type Initialized = TestInitialized;
 	type InitializationPayment = TestInitializationPayment;
-	type MinimumContribution = TestMinimumContribution;
+	type MinimumReward = TestMinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingPeriod = TestVestingPeriod;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -30,7 +30,6 @@ use frame_support::{
 use frame_system::RawOrigin;
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
-use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -39,11 +38,9 @@ use sp_runtime::{
 use sp_std::convert::{From, TryInto};
 
 pub type Balance = u128;
+
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
-
-pub type Signature = account::EthereumSignature;
-pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 construct_runtime!(
 	pub enum Test where
@@ -89,7 +86,7 @@ impl frame_system::Config for Test {
 	type BlockNumber = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
-	type AccountId = AccountId;
+	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type Event = Event;
@@ -127,8 +124,6 @@ parameter_types! {
 }
 
 impl Config for Test {
-	type Public = account::EthereumSigner;
-	type Signature = Signature;
 	type Event = Event;
 	type Initialized = TestInitialized;
 	type InitializationPayment = TestInitializationPayment;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -170,7 +170,7 @@ pub(crate) fn get_ed25519_pairs(num: u32) -> Vec<ed25519::Pair> {
 }
 
 pub(crate) fn empty() -> sp_io::TestExternalities {
-	genesis(100000u32.into())
+	genesis(2500u32.into())
 }
 
 pub(crate) fn events() -> Vec<super::Event<Test>> {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -30,6 +30,7 @@ use frame_support::{
 use frame_system::RawOrigin;
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
+use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -38,9 +39,11 @@ use sp_runtime::{
 use sp_std::convert::{From, TryInto};
 
 pub type Balance = u128;
-
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
+
+pub type Signature = account::SubstrateSignature;
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 construct_runtime!(
 	pub enum Test where
@@ -86,7 +89,7 @@ impl frame_system::Config for Test {
 	type BlockNumber = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
-	type AccountId = u64;
+	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
 	type Event = Event;
@@ -124,6 +127,8 @@ parameter_types! {
 }
 
 impl Config for Test {
+	type Public = account::EthereumSigner;
+	type Signature = Signature;
 	type Event = Event;
 	type Initialized = TestInitialized;
 	type InitializationPayment = TestInitializationPayment;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -42,7 +42,7 @@ pub type Balance = u128;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
-pub type Signature = account::SubstrateSignature;
+pub type Signature = account::EthereumSignature;
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
 construct_runtime!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -355,12 +355,12 @@ fn initialize_new_addresses_with_batch() {
 		roll_to(10);
 		assert_ok!(mock::Call::Utility(UtilityCall::batch_all(vec![
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([4u8; 32].into(), Some(3), 500)],
+				vec![([4u8; 32].into(), Some(3), 1250)],
 				0,
 				2
 			)),
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([5u8; 32].into(), Some(1), 500)],
+				vec![([5u8; 32].into(), Some(1), 1250)],
 				1,
 				2
 			))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,14 +16,11 @@
 
 //! Unit testing
 use crate::*;
-use account::{EthereumSignature, EthereumSigner};
 use frame_support::dispatch::{DispatchError, Dispatchable};
 use frame_support::{assert_noop, assert_ok};
 use mock::*;
 use parity_scale_codec::Encode;
-use sha3::{Digest, Keccak256};
-use sp_core::{ecdsa, Pair, H160};
-use sp_runtime::traits::IdentifyAccount;
+use sp_core::Pair;
 use sp_runtime::MultiSignature;
 
 #[test]
@@ -35,8 +32,8 @@ fn geneses() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into()),
-				([2u8; 32].into(), Some(H160::from([2u8; 20])), 500u32.into()),
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
 				(pairs[1].public().into(), None, 500u32.into()),
 				(pairs[2].public().into(), None, 500u32.into())
@@ -45,11 +42,11 @@ fn geneses() {
 			5
 		));
 		// accounts_payable
-		assert!(Crowdloan::accounts_payable(&H160::from([1u8; 20])).is_some());
-		assert!(Crowdloan::accounts_payable(&H160::from([2u8; 20])).is_some());
-		assert!(Crowdloan::accounts_payable(&H160::from([3u8; 20])).is_none());
-		assert!(Crowdloan::accounts_payable(&H160::from([4u8; 20])).is_none());
-		assert!(Crowdloan::accounts_payable(&H160::from([5u8; 20])).is_none());
+		assert!(Crowdloan::accounts_payable(&1).is_some());
+		assert!(Crowdloan::accounts_payable(&2).is_some());
+		assert!(Crowdloan::accounts_payable(&3).is_none());
+		assert!(Crowdloan::accounts_payable(&4).is_none());
+		assert!(Crowdloan::accounts_payable(&5).is_none());
 
 		// claimed address existence
 		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
@@ -70,15 +67,15 @@ fn geneses() {
 #[test]
 fn proving_assignation_works() {
 	let pairs = get_ed25519_pairs(3);
-	let signature: MultiSignature = pairs[0].sign(&H160::from([3u8; 20]).encode()).into();
+	let signature: MultiSignature = pairs[0].sign(&3u64.encode()).into();
 	empty().execute_with(|| {
 		// Insert contributors
 		let pairs = get_ed25519_pairs(3);
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into()),
-				([2u8; 32].into(), Some(H160::from([2u8; 20])), 500u32.into()),
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
 				(pairs[1].public().into(), None, 500u32.into()),
 				(pairs[2].public().into(), None, 500u32.into())
@@ -87,13 +84,13 @@ fn proving_assignation_works() {
 			5
 		));
 		// 4 is not payable first
-		assert!(Crowdloan::accounts_payable(&H160::from([3u8; 20])).is_none());
+		assert!(Crowdloan::accounts_payable(&3).is_none());
 		roll_to(4);
 		// Signature is wrong, prove fails
 		assert_noop!(
 			Crowdloan::associate_native_identity(
-				Origin::signed(H160::from([4u8; 20])),
-				H160::from([4u8; 20]),
+				Origin::signed(4),
+				4,
 				pairs[0].public().into(),
 				signature.clone()
 			),
@@ -101,35 +98,31 @@ fn proving_assignation_works() {
 		);
 		// Signature is right, prove passes
 		assert_ok!(Crowdloan::associate_native_identity(
-			Origin::signed(H160::from([4u8; 20])),
-			H160::from([3u8; 20]),
+			Origin::signed(4),
+			3,
 			pairs[0].public().into(),
 			signature.clone()
 		));
 		// Signature is right, but address already claimed
 		assert_noop!(
 			Crowdloan::associate_native_identity(
-				Origin::signed(H160::from([4u8; 20])),
-				H160::from([3u8; 20]),
+				Origin::signed(4),
+				3,
 				pairs[0].public().into(),
 				signature
 			),
 			Error::<Test>::AlreadyAssociated
 		);
 		// now three is payable
-		assert!(Crowdloan::accounts_payable(&H160::from([3u8; 20])).is_some());
+		assert!(Crowdloan::accounts_payable(&3).is_some());
 		assert!(Crowdloan::unassociated_contributions(pairs[0].public().as_array_ref()).is_none());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).is_some());
 
 		let expected = vec![
-			crate::Event::InitialPaymentMade(H160::from([1u8; 20]), 100),
-			crate::Event::InitialPaymentMade(H160::from([2u8; 20]), 100),
-			crate::Event::InitialPaymentMade(H160::from([3u8; 20]), 100),
-			crate::Event::NativeIdentityAssociated(
-				pairs[0].public().into(),
-				H160::from([3u8; 20]),
-				500,
-			),
+			crate::Event::InitialPaymentMade(1, 100),
+			crate::Event::InitialPaymentMade(2, 100),
+			crate::Event::InitialPaymentMade(3, 100),
+			crate::Event::NativeIdentityAssociated(pairs[0].public().into(), 3, 500),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -143,8 +136,8 @@ fn paying_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into()),
-				([2u8; 32].into(), Some(H160::from([2u8; 20])), 500u32.into()),
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
 				(pairs[1].public().into(), None, 500u32.into()),
 				(pairs[2].public().into(), None, 500u32.into())
@@ -153,99 +146,44 @@ fn paying_works() {
 			5
 		));
 		// 1 is payable
-		assert!(Crowdloan::accounts_payable(&H160::from([1u8; 20])).is_some());
+		assert!(Crowdloan::accounts_payable(&1).is_some());
 		roll_to(4);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[1u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.last_paid,
-			4u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			300
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 4u64);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 300);
 		assert_noop!(
-			Crowdloan::show_me_the_money(Origin::signed(H160::from([3u8; 20]))),
+			Crowdloan::show_me_the_money(Origin::signed(3)),
 			Error::<Test>::NoAssociatedClaim
 		);
 		roll_to(5);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[1u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.last_paid,
-			5u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			350
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 5u64);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 350);
 		roll_to(6);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[1u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.last_paid,
-			6u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			400
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 6u64);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 400);
 		roll_to(7);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[1u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.last_paid,
-			7u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			450
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().last_paid, 7u64);
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 450);
 		roll_to(230);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[1u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([1u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			500
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 500);
 		roll_to(330);
 		assert_noop!(
-			Crowdloan::show_me_the_money(Origin::signed(H160::from([1u8; 20]))),
+			Crowdloan::show_me_the_money(Origin::signed(1)),
 			Error::<Test>::RewardsAlreadyClaimed
 		);
 
 		let expected = vec![
-			crate::Event::InitialPaymentMade(H160::from([1u8; 20]), 100),
-			crate::Event::InitialPaymentMade(H160::from([2u8; 20]), 100),
-			crate::Event::RewardsPaid(H160::from([1u8; 20]), 200),
-			crate::Event::RewardsPaid(H160::from([1u8; 20]), 50),
-			crate::Event::RewardsPaid(H160::from([1u8; 20]), 50),
-			crate::Event::RewardsPaid(H160::from([1u8; 20]), 50),
-			crate::Event::RewardsPaid(H160::from([1u8; 20]), 50),
+			crate::Event::InitialPaymentMade(1, 100),
+			crate::Event::InitialPaymentMade(2, 100),
+			crate::Event::RewardsPaid(1, 200),
+			crate::Event::RewardsPaid(1, 50),
+			crate::Event::RewardsPaid(1, 50),
+			crate::Event::RewardsPaid(1, 50),
+			crate::Event::RewardsPaid(1, 50),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -254,15 +192,15 @@ fn paying_works() {
 #[test]
 fn paying_late_joiner_works() {
 	let pairs = get_ed25519_pairs(3);
-	let signature: MultiSignature = pairs[0].sign(&H160::from([3u8; 20]).encode()).into();
+	let signature: MultiSignature = pairs[0].sign(&3u64.encode()).into();
 	empty().execute_with(|| {
 		// Insert contributors
 		let pairs = get_ed25519_pairs(3);
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into()),
-				([2u8; 32].into(), Some(H160::from([2u8; 20])), 500u32.into()),
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
 				(pairs[1].public().into(), None, 500u32.into()),
 				(pairs[2].public().into(), None, 500u32.into())
@@ -272,36 +210,20 @@ fn paying_late_joiner_works() {
 		));
 		roll_to(12);
 		assert_ok!(Crowdloan::associate_native_identity(
-			Origin::signed(H160::from([4u8; 20])),
-			H160::from([3u8; 20]),
+			Origin::signed(4),
+			3,
 			pairs[0].public().into(),
 			signature.clone()
 		));
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[3u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([3u8; 20]))
-				.unwrap()
-				.last_paid,
-			12u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([3u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			500
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(3)));
+		assert_eq!(Crowdloan::accounts_payable(&3).unwrap().last_paid, 12u64);
+		assert_eq!(Crowdloan::accounts_payable(&3).unwrap().claimed_reward, 500);
 		let expected = vec![
-			crate::Event::InitialPaymentMade(H160::from([1u8; 20]), 100),
-			crate::Event::InitialPaymentMade(H160::from([2u8; 20]), 100),
-			crate::Event::InitialPaymentMade(H160::from([3u8; 20]), 100),
-			crate::Event::NativeIdentityAssociated(
-				pairs[0].public().into(),
-				H160::from([3u8; 20]),
-				500,
-			),
-			crate::Event::RewardsPaid(H160::from([3u8; 20]), 400),
+			crate::Event::InitialPaymentMade(1, 100),
+			crate::Event::InitialPaymentMade(2, 100),
+			crate::Event::InitialPaymentMade(3, 100),
+			crate::Event::NativeIdentityAssociated(pairs[0].public().into(), 3, 500),
+			crate::Event::RewardsPaid(3, 400),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -315,8 +237,8 @@ fn update_address_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into()),
-				([2u8; 32].into(), Some(H160::from([2u8; 20])), 500u32.into()),
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
 				(pairs[1].public().into(), None, 500u32.into()),
 				(pairs[2].public().into(), None, 500u32.into())
@@ -326,52 +248,25 @@ fn update_address_works() {
 		));
 
 		roll_to(4);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[1u8; 20]
-		))));
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
 		assert_noop!(
-			Crowdloan::show_me_the_money(Origin::signed(H160::from([8u8; 20]))),
+			Crowdloan::show_me_the_money(Origin::signed(8)),
 			Error::<Test>::NoAssociatedClaim
 		);
-		assert_ok!(Crowdloan::update_reward_address(
-			Origin::signed(H160::from([1u8; 20])),
-			H160::from([8u8; 20])
-		));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([8u8; 20]))
-				.unwrap()
-				.last_paid,
-			4u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([8u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			300
-		);
+		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
+		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().last_paid, 4u64);
+		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 300);
 		roll_to(6);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[8u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([8u8; 20]))
-				.unwrap()
-				.last_paid,
-			6u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([8u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			400
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(8)));
+		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().last_paid, 6u64);
+		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 400);
 		// The initial payment is not
 		let expected = vec![
-			crate::Event::InitialPaymentMade(H160::from([1u8; 20]), 100),
-			crate::Event::InitialPaymentMade(H160::from([2u8; 20]), 100),
-			crate::Event::RewardsPaid(H160::from([1u8; 20]), 200),
-			crate::Event::RewardAddressUpdated(H160::from([1u8; 20]), H160::from([8u8; 20])),
-			crate::Event::RewardsPaid(H160::from([8u8; 20]), 100),
+			crate::Event::InitialPaymentMade(1, 100),
+			crate::Event::InitialPaymentMade(2, 100),
+			crate::Event::RewardsPaid(1, 200),
+			crate::Event::RewardAddressUpdated(1, 8),
+			crate::Event::RewardsPaid(8, 100),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -385,8 +280,8 @@ fn update_address_with_existing_address_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into()),
-				([2u8; 32].into(), Some(H160::from([2u8; 20])), 500u32.into()),
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
 				(pairs[1].public().into(), None, 500u32.into()),
 				(pairs[2].public().into(), None, 500u32.into())
@@ -396,55 +291,26 @@ fn update_address_with_existing_address_works() {
 		));
 
 		roll_to(4);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[1u8; 20]
-		))));
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[2u8; 20]
-		))));
-		assert_ok!(Crowdloan::update_reward_address(
-			Origin::signed(H160::from([1u8; 20])),
-			H160::from([2u8; 20])
-		));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([2u8; 20]))
-				.unwrap()
-				.last_paid,
-			4u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([2u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			600
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(1)));
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(2)));
+		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().last_paid, 4u64);
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 600);
 		assert_noop!(
-			Crowdloan::show_me_the_money(Origin::signed(H160::from([1u8; 20]))),
+			Crowdloan::show_me_the_money(Origin::signed(1)),
 			Error::<Test>::NoAssociatedClaim
 		);
 		roll_to(6);
-		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(H160::from(
-			[2u8; 20]
-		))));
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([2u8; 20]))
-				.unwrap()
-				.last_paid,
-			6u64
-		);
-		assert_eq!(
-			Crowdloan::accounts_payable(&H160::from([2u8; 20]))
-				.unwrap()
-				.claimed_reward,
-			800
-		);
+		assert_ok!(Crowdloan::show_me_the_money(Origin::signed(2)));
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().last_paid, 6u64);
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 800);
 		let expected = vec![
-			crate::Event::InitialPaymentMade(H160::from([1u8; 20]), 100),
-			crate::Event::InitialPaymentMade(H160::from([2u8; 20]), 100),
-			crate::Event::RewardsPaid(H160::from([1u8; 20]), 200),
-			crate::Event::RewardsPaid(H160::from([2u8; 20]), 200),
-			crate::Event::RewardAddressUpdated(H160::from([1u8; 20]), H160::from([2u8; 20])),
-			crate::Event::RewardsPaid(H160::from([2u8; 20]), 200),
+			crate::Event::InitialPaymentMade(1, 100),
+			crate::Event::InitialPaymentMade(2, 100),
+			crate::Event::RewardsPaid(1, 200),
+			crate::Event::RewardsPaid(2, 200),
+			crate::Event::RewardAddressUpdated(1, 2),
+			crate::Event::RewardsPaid(2, 200),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -459,8 +325,8 @@ fn initialize_new_addresses() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into()),
-				([2u8; 32].into(), Some(H160::from([2u8; 20])), 500u32.into()),
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
 				(pairs[1].public().into(), None, 500u32.into()),
 				(pairs[2].public().into(), None, 500u32.into())
@@ -474,7 +340,7 @@ fn initialize_new_addresses() {
 		assert_noop!(
 			Crowdloan::initialize_reward_vec(
 				Origin::root(),
-				vec![([1u8; 32].into(), Some(H160::from([1u8; 20])), 500u32.into())],
+				vec![([1u8; 32].into(), Some(1), 500u32.into())],
 				0,
 				1
 			),
@@ -490,12 +356,12 @@ fn initialize_new_addresses_with_batch() {
 		roll_to(10);
 		assert_ok!(mock::Call::Utility(UtilityCall::batch_all(vec![
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([4u8; 32].into(), Some(H160::from([3u8; 20])), 1250)],
+				vec![([4u8; 32].into(), Some(3), 1250)],
 				0,
 				2
 			)),
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([5u8; 32].into(), Some(H160::from([1u8; 20])), 1250)],
+				vec![([5u8; 32].into(), Some(1), 1250)],
 				1,
 				2
 			))
@@ -505,11 +371,7 @@ fn initialize_new_addresses_with_batch() {
 		// Batch calls always succeed. We just need to check the inner event
 		assert_ok!(
 			mock::Call::Utility(UtilityCall::batch(vec![mock::Call::Crowdloan(
-				crate::Call::initialize_reward_vec(
-					vec![([4u8; 32].into(), Some(H160::from([3u8; 20])), 500)],
-					0,
-					1
-				)
+				crate::Call::initialize_reward_vec(vec![([4u8; 32].into(), Some(3), 500)], 0, 1)
 			)]))
 			.dispatch(Origin::root())
 		);
@@ -532,31 +394,15 @@ fn initialize_new_addresses_with_batch() {
 #[test]
 fn first_free_claim_should_work() {
 	empty().execute_with(|| {
-		let secret_key = [1u8; 32];
-		let secret = secp256k1::SecretKey::parse_slice(&secret_key).unwrap();
-		let pair = ecdsa::Pair::from_seed_slice(&secret_key).unwrap();
-
-		let account: EthereumSigner = pair.public().into();
-
-		let data = account.using_encoded(to_ascii_hex);
-
-		let mut m = [0u8; 32];
-		m.copy_from_slice(Keccak256::digest(&data).as_slice());
-
-		let message = secp256k1::Message::parse(&m);
-		let signature: ecdsa::Signature = secp256k1::sign(&message, &secret).into();
-
-		let new_signature: EthereumSignature = signature.into();
-
 		roll_to(2);
 		assert_ok!(mock::Call::Utility(UtilityCall::batch_all(vec![
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([4u8; 32].into(), Some(account.clone().into_account()), 1250)],
+				vec![([4u8; 32].into(), Some(1), 1250)],
 				0,
 				2
 			)),
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([5u8; 32].into(), Some(H160::from([1u8; 20])), 1250)],
+				vec![([5u8; 32].into(), Some(2), 1250)],
 				1,
 				2
 			))
@@ -564,123 +410,26 @@ fn first_free_claim_should_work() {
 		.dispatch(Origin::root()));
 
 		assert_eq!(
-			Crowdloan::accounts_payable(&account.clone().into_account())
-				.unwrap()
-				.claimed_reward,
+			Crowdloan::accounts_payable(&2).unwrap().claimed_reward,
 			250u128
 		);
 
 		// Block relay number is 2 post init initialization
 		roll_to(4);
 
-		assert_ok!(Crowdloan::my_first_claim(
-			Origin::none(),
-			account.clone().into_account(),
-			new_signature.clone().into()
-		));
+		assert_ok!(Crowdloan::my_first_claim(Origin::signed(2)));
+
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().last_paid, 4u64);
 
 		assert_eq!(
-			Crowdloan::accounts_payable(&account.clone().into_account())
-				.unwrap()
-				.last_paid,
-			4u64
-		);
-
-		assert_eq!(
-			Crowdloan::accounts_payable(&account.clone().into_account())
-				.unwrap()
-				.claimed_reward,
+			Crowdloan::accounts_payable(&2).unwrap().claimed_reward,
 			500u128
 		);
 
 		// I cannot do this claim anymore
 		assert_noop!(
-			Crowdloan::my_first_claim(
-				Origin::none(),
-				account.clone().into_account(),
-				new_signature.into()
-			),
+			Crowdloan::my_first_claim(Origin::signed(2)),
 			Error::<Test>::FirstClaimAlreadyDone
-		);
-	});
-}
-
-#[test]
-fn free_claim_with_invalid_signature_does_not_work() {
-	empty().execute_with(|| {
-		let secret_key = [1u8; 32];
-		let secret_key2 = [2u8; 32];
-		let secret2 = secp256k1::SecretKey::parse_slice(&secret_key2).unwrap();
-		let pair = ecdsa::Pair::from_seed_slice(&secret_key).unwrap();
-		let pair2 = ecdsa::Pair::from_seed_slice(&secret_key2).unwrap();
-
-		let account: EthereumSigner = pair.public().into();
-		let account2: EthereumSigner = pair2.public().into();
-		let data = account.using_encoded(to_ascii_hex);
-		let data2 = account2.using_encoded(to_ascii_hex);
-
-		// We create a fake signature, account 2 signing account 1 payload
-		let mut m = [0u8; 32];
-		m.copy_from_slice(Keccak256::digest(&data).as_slice());
-
-		let message = secp256k1::Message::parse(&m);
-		let signature: ecdsa::Signature = secp256k1::sign(&message, &secret2).into();
-
-		let fake_sig: EthereumSignature = signature.into();
-
-		// We create a valid payload, accounnt 2 signing account 2
-		let mut m = [0u8; 32];
-		m.copy_from_slice(Keccak256::digest(&data2).as_slice());
-
-		let message2 = secp256k1::Message::parse(&m);
-		let signature: ecdsa::Signature = secp256k1::sign(&message2, &secret2).into();
-
-		let signature2: EthereumSignature = signature.into();
-
-		roll_to(2);
-		assert_ok!(mock::Call::Utility(UtilityCall::batch_all(vec![
-			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([4u8; 32].into(), Some(account.clone().into_account()), 1250)],
-				0,
-				2
-			)),
-			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([5u8; 32].into(), Some(H160::from([1u8; 20])), 1250)],
-				1,
-				2
-			))
-		]))
-		.dispatch(Origin::root()));
-
-		// We made a first payment
-
-		assert_eq!(
-			Crowdloan::accounts_payable(&account.clone().into_account())
-				.unwrap()
-				.claimed_reward,
-			250u128
-		);
-
-		roll_to(4);
-
-		// Here the siganture is done signing account 1 instead of 2. Wrong sig error
-		assert_noop!(
-			Crowdloan::my_first_claim(
-				Origin::none(),
-				account2.clone().into_account(),
-				fake_sig.into()
-			),
-			Error::<Test>::InvalidFreeClaimSignature
-		);
-
-		// Correct signature but no associated claim
-		assert_noop!(
-			Crowdloan::my_first_claim(
-				Origin::none(),
-				account2.clone().into_account(),
-				signature2.into()
-			),
-			Error::<Test>::NoAssociatedClaim
 		);
 	});
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -32,13 +32,12 @@ fn geneses() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([2u8; 32].into(), Some(2), 500),
-				(pairs[0].public().into(), None, 500),
-				(pairs[1].public().into(), None, 500),
-				(pairs[2].public().into(), None, 500)
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[2].public().into(), None, 500u32.into())
 			],
-			1,
 			0,
 			5
 		));
@@ -74,13 +73,12 @@ fn proving_assignation_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([2u8; 32].into(), Some(2), 500),
-				(pairs[0].public().into(), None, 500),
-				(pairs[1].public().into(), None, 500),
-				(pairs[2].public().into(), None, 500)
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[2].public().into(), None, 500u32.into())
 			],
-			1,
 			0,
 			5
 		));
@@ -137,13 +135,12 @@ fn paying_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([2u8; 32].into(), Some(2), 500),
-				(pairs[0].public().into(), None, 500),
-				(pairs[1].public().into(), None, 500),
-				(pairs[2].public().into(), None, 500)
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[2].public().into(), None, 500u32.into())
 			],
-			1,
 			0,
 			5
 		));
@@ -201,13 +198,12 @@ fn paying_late_joiner_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([2u8; 32].into(), Some(2), 500),
-				(pairs[0].public().into(), None, 500),
-				(pairs[1].public().into(), None, 500),
-				(pairs[2].public().into(), None, 500)
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[2].public().into(), None, 500u32.into())
 			],
-			1,
 			0,
 			5
 		));
@@ -240,13 +236,12 @@ fn update_address_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([2u8; 32].into(), Some(2), 500),
-				(pairs[0].public().into(), None, 500),
-				(pairs[1].public().into(), None, 500),
-				(pairs[2].public().into(), None, 500)
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[2].public().into(), None, 500u32.into())
 			],
-			1,
 			0,
 			5
 		));
@@ -284,13 +279,12 @@ fn update_address_with_existing_address_works() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([2u8; 32].into(), Some(2), 500),
-				(pairs[0].public().into(), None, 500),
-				(pairs[1].public().into(), None, 500),
-				(pairs[2].public().into(), None, 500)
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[2].public().into(), None, 500u32.into())
 			],
-			1,
 			0,
 			5
 		));
@@ -330,13 +324,12 @@ fn initialize_new_addresses() {
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
-				([1u8; 32].into(), Some(1), 500),
-				([2u8; 32].into(), Some(2), 500),
-				(pairs[0].public().into(), None, 500),
-				(pairs[1].public().into(), None, 500),
-				(pairs[2].public().into(), None, 500)
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[2].public().into(), None, 500u32.into())
 			],
-			1,
 			0,
 			5
 		));
@@ -346,8 +339,7 @@ fn initialize_new_addresses() {
 		assert_noop!(
 			Crowdloan::initialize_reward_vec(
 				Origin::root(),
-				vec![([1u8; 32].into(), Some(1), 500)],
-				1,
+				vec![([1u8; 32].into(), Some(1), 500u32.into())],
 				0,
 				1
 			),
@@ -364,13 +356,11 @@ fn initialize_new_addresses_with_batch() {
 		assert_ok!(mock::Call::Utility(UtilityCall::batch_all(vec![
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
 				vec![([4u8; 32].into(), Some(3), 500)],
-				1,
 				0,
 				2
 			)),
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
 				vec![([5u8; 32].into(), Some(1), 500)],
-				1,
 				1,
 				2
 			))
@@ -380,7 +370,7 @@ fn initialize_new_addresses_with_batch() {
 		// Batch calls always succeed. We just need to check the inner event
 		assert_ok!(
 			mock::Call::Utility(UtilityCall::batch(vec![mock::Call::Crowdloan(
-				crate::Call::initialize_reward_vec(vec![([4u8; 32].into(), Some(3), 500)], 1, 0, 1)
+				crate::Call::initialize_reward_vec(vec![([4u8; 32].into(), Some(3), 500)], 0, 1)
 			)]))
 			.dispatch(Origin::root())
 		);


### PR DESCRIPTION

It adds:

- A free claim (signed extrinsic) that pays 0 fees the first time
- Removes the fixed point arithmetic by inserting directly the rewards to be received instead of the contribution and multiplier
- Checker that the fund matches the rewards
