### PR TITLE
Improvements without free claim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,22 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          components: rustfmt, clippy
+      - name: Setup Rust toolchain
+        run: rustup show
 
       - name: Formatter
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --verbose
+        run: cargo test --release --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,15 @@ parity-scale-codec = { version = "2.1.1", default-features = false}
 serde = { version = "1.0.101", optional = true, features = ["derive"], default-features = false }
 log = { version = "0.4", default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false, optional = true }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.2" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.2" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.2" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.2" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.2" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.2" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false, optional = true }
 cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ sp-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false, optional = true }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ sp-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.2", default-features = false, optional = true }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "notlesh-nimbus-merge-polkadot-v0.9.2" }
 
 [features]
 default = ["std"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2021-02-21"
+components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,14 +257,14 @@ pub mod pallet {
 			// Substract the first payment from the vested amount
 			let first_paid = T::InitializationPayment::get() * info.total_reward;
 
-			// Vesting perdiods as u32
+			// Vesting perdiods as balance
 			let vesting_period = T::VestingPeriod::get()
 				.saturated_into::<u128>()
 				.try_into()
 				.ok()
 				.ok_or(Error::<T>::WrongConversionU128ToBalance)?;
 
-			// 	To calculate how much could the user have claimed already
+			// To calculate how much could the user have claimed already
 			let payable_period = now.saturating_sub(<InitRelayBlock<T>>::get().into());
 
 			let pay_period_as_balance: BalanceOf<T> = payable_period
@@ -286,7 +286,7 @@ pub mod pallet {
 				should_have_claimed + first_paid - info.claimed_reward
 			};
 
-			// Does this come from first payment?
+			// If first payment does not pay fees
 			let result: PostDispatchInfo = if !info.free_claim_done {
 				info.free_claim_done = true;
 				PostDispatchInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,13 +258,13 @@ pub mod pallet {
 			let first_paid = T::InitializationPayment::get() * info.total_reward;
 
 			// Vesting perdiods as u32
-
 			let vesting_period = T::VestingPeriod::get()
 				.saturated_into::<u128>()
 				.try_into()
 				.ok()
 				.ok_or(Error::<T>::WrongConversionU128ToBalance)?;
 
+			// 	To calculate how much could the user have claimed already
 			let payable_period = now.saturating_sub(<InitRelayBlock<T>>::get().into());
 
 			let pay_period_as_balance: BalanceOf<T> = payable_period
@@ -273,15 +273,11 @@ pub mod pallet {
 				.ok()
 				.ok_or(Error::<T>::WrongConversionU128ToBalance)?;
 
-			// How much should the contributor have already gained?
+			// How much should the contributor have already claimed by this block?
+			// By multiplying first we allow the conversion to integer done with the biggest number
 			let should_have_claimed = pay_period_as_balance
 				.saturating_mul(info.total_reward - first_paid)
 				/ vesting_period;
-			println!("Should have paid {:?}", should_have_claimed);
-			println!("Total Reward {:?}", info.total_reward);
-			println!("First Paid {:?}", first_paid);
-			println!("Vesting Period {:?}", vesting_period);
-			println!("pay_period_as_balance{:?}", pay_period_as_balance);
 
 			// If the period is bigger than whats missing to pay, then return whats missing to pay
 			let payable_amount = if should_have_claimed >= info.total_reward {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub mod pallet {
 	use frame_support::{
 		dispatch::fmt::Debug,
 		pallet_prelude::*,
-		traits::{Currency, ExistenceRequirement::KeepAlive},
+		traits::{Currency, ExistenceRequirement::AllowDeath},
 		PalletId,
 	};
 	use frame_system::pallet_prelude::*;
@@ -200,7 +200,7 @@ pub mod pallet {
 				&PALLET_ID.into_account(),
 				&reward_account,
 				first_payment,
-				KeepAlive,
+				AllowDeath,
 			)?;
 
 			Self::deposit_event(Event::InitialPaymentMade(
@@ -306,7 +306,7 @@ pub mod pallet {
 				&PALLET_ID.into_account(),
 				&payee,
 				payable_amount,
-				KeepAlive,
+				AllowDeath,
 			)?;
 			// Emit event
 			Self::deposit_event(Event::RewardsPaid(payee, payable_amount));
@@ -428,7 +428,7 @@ pub mod pallet {
 						&PALLET_ID.into_account(),
 						&native_account,
 						first_payment,
-						KeepAlive,
+						AllowDeath,
 					)?;
 					Self::deposit_event(Event::InitialPaymentMade(
 						native_account.clone(),

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -64,10 +64,11 @@ impl cumulus_pallet_parachain_system::Config for Test {
 	type SelfParaId = ParachainId;
 	type Event = Event;
 	type OnValidationData = ();
-	type DownwardMessageHandlers = ();
 	type OutboundXcmpMessageSource = ();
 	type XcmpMessageHandler = ();
 	type ReservedXcmpWeight = ();
+	type DmpMessageHandler = ();
+	type ReservedDmpWeight = ();
 }
 
 parameter_types! {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -382,7 +382,7 @@ fn initialize_new_addresses_with_batch() {
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 7,
+					error: 8,
 					message: None,
 				},
 			),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,7 +17,6 @@
 //! Unit testing
 use crate::*;
 use frame_support::dispatch::{DispatchError, Dispatchable};
-use frame_support::weights::Pays;
 use frame_support::{assert_noop, assert_ok};
 use mock::*;
 use parity_scale_codec::Encode;
@@ -597,50 +596,5 @@ fn reward_below_vesting_period_works() {
 			crate::Event::RewardsPaid(3, 3),
 		];
 		assert_eq!(events(), expected);
-	});
-}
-
-#[test]
-fn first_free_claim_should_work() {
-	empty().execute_with(|| {
-		roll_to(2);
-		assert_ok!(mock::Call::Utility(UtilityCall::batch_all(vec![
-			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([4u8; 32].into(), Some(1), 1250)],
-				0,
-				2
-			)),
-			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(
-				vec![([5u8; 32].into(), Some(2), 1250)],
-				1,
-				2
-			))
-		]))
-		.dispatch(Origin::root()));
-
-		assert_eq!(
-			Crowdloan::accounts_payable(&2).unwrap().claimed_reward,
-			250u128
-		);
-
-		// Block relay number is 2 post init initialization
-		roll_to(4);
-
-		// First one is free
-		let post_info = Crowdloan::show_me_the_money(Origin::signed(2)).unwrap();
-
-		assert_eq!(post_info.pays_fee, Pays::No);
-
-		assert_eq!(
-			Crowdloan::accounts_payable(&2).unwrap().claimed_reward,
-			500u128
-		);
-
-		// Block relay number is 2 post init initialization
-		roll_to(4);
-
-		// Second one is not
-		let post_info = Crowdloan::show_me_the_money(Origin::signed(2)).unwrap();
-		assert_eq!(post_info.pays_fee, Pays::Yes);
 	});
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,8 +17,8 @@
 //! Unit testing
 use crate::*;
 use frame_support::dispatch::{DispatchError, Dispatchable};
-use frame_support::{assert_noop, assert_ok};
 use frame_support::weights::Pays;
+use frame_support::{assert_noop, assert_ok};
 use mock::*;
 use parity_scale_codec::Encode;
 use sp_core::Pair;
@@ -630,7 +630,7 @@ fn first_free_claim_should_work() {
 		let post_info = Crowdloan::show_me_the_money(Origin::signed(2)).unwrap();
 
 		assert_eq!(post_info.pays_fee, Pays::No);
-		
+
 		assert_eq!(
 			Crowdloan::accounts_payable(&2).unwrap().claimed_reward,
 			500u128


### PR DESCRIPTION
This PR adds:

- some more sanity checks for the initialization

- not let users claim money if reward vec is not fully initialized.
- Correct arithmetic by comparing how much should an account have vested vs how much it already vested, and pay the difference.
- Add more tests for the floating point arithmetic problem
- Removal of first free claim.

This PR is the same as https://github.com/PureStake/crowdloan-rewards/pull/10 but changes the reward payment method. Either #10 or this PR should be merged
Closes #9