### PR TITLE
Store num contributors and intiialized total rewards

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,9 @@ pub mod pallet {
 			// What is the amount initialized so far?
 			let mut current_initialized_rewards = InitializedRewardAmount::<T>::get();
 
+			// Total number of contributors
+			let mut total_contributors = TotalContributors::<T>::get();
+
 			let incoming_rewards: BalanceOf<T> = rewards
 				.iter()
 				.fold(0u32.into(), |acc: BalanceOf<T>, (_, _, reward)| {
@@ -407,6 +410,7 @@ pub mod pallet {
 				};
 
 				current_initialized_rewards += *reward - initial_payment;
+				total_contributors += 1;
 
 				if let Some(native_account) = native_account {
 					AccountsPayable::<T>::insert(native_account, reward_info);
@@ -416,6 +420,7 @@ pub mod pallet {
 				}
 			}
 			InitializedRewardAmount::<T>::put(current_initialized_rewards);
+			TotalContributors::<T>::put(total_contributors);
 			// Let's ensure we can close initialization
 			if index + rewards.len() as u32 == limit {
 				<Initialized<T>>::put(true);
@@ -515,6 +520,11 @@ pub mod pallet {
 	/// Total initialized amount so far. We store this to make pallet funds == contributors reward
 	/// check easier and more efficient
 	type InitializedRewardAmount<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn total_contributors)]
+	/// Total number of contributors to aid hinting benchmarking
+	type TotalContributors<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(fn deposit_event)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,17 +334,8 @@ pub mod pallet {
 				Error::<T>::RewardVecAlreadyInitialized
 			);
 
-			let claimed_rewards = AccountsPayable::<T>::iter().fold(
-				0u32.into(),
-				|acc: BalanceOf<T>, (_, reward_info)| {
-					acc + reward_info.total_reward - reward_info.claimed_reward
-				},
-			);
-
-			let unassociated_rewards = UnassociatedContributions::<T>::iter()
-				.fold(0u32.into(), |acc: BalanceOf<T>, (_, reward_info)| {
-					acc + reward_info.total_reward
-				});
+			// What is the amount initialized so far?
+			let mut current_initialized_rewards = InitializedRewardAmount::<T>::get();
 
 			let incoming_rewards: BalanceOf<T> = rewards
 				.iter()
@@ -354,14 +345,14 @@ pub mod pallet {
 
 			// Ensure we dont go over funds
 			ensure!(
-				claimed_rewards + unassociated_rewards + incoming_rewards <= Self::pot(),
+				current_initialized_rewards + incoming_rewards <= Self::pot(),
 				Error::<T>::BatchBeyondFundPot
 			);
 
 			// Let's ensure we can close initialization
 			if index + rewards.len() as u32 == limit {
 				ensure!(
-					claimed_rewards + unassociated_rewards + incoming_rewards == Self::pot(),
+					current_initialized_rewards + incoming_rewards == Self::pot(),
 					Error::<T>::RewardsDoNotMatchFund
 				);
 			}
@@ -415,6 +406,8 @@ pub mod pallet {
 					claimed_reward: initial_payment,
 				};
 
+				current_initialized_rewards += *reward - initial_payment;
+
 				if let Some(native_account) = native_account {
 					AccountsPayable::<T>::insert(native_account, reward_info);
 					ClaimedRelayChainIds::<T>::insert(relay_account, ());
@@ -422,6 +415,7 @@ pub mod pallet {
 					UnassociatedContributions::<T>::insert(relay_account, reward_info);
 				}
 			}
+			InitializedRewardAmount::<T>::put(current_initialized_rewards);
 			// Let's ensure we can close initialization
 			if index + rewards.len() as u32 == limit {
 				<Initialized<T>>::put(true);
@@ -515,6 +509,12 @@ pub mod pallet {
 	#[pallet::getter(fn init_relay_block)]
 	/// Relay block height at the initialization of the pallet
 	type InitRelayBlock<T: Config> = StorageValue<_, relay_chain::BlockNumber, ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn init_reward_amount)]
+	/// Total initialized amount so far. We store this to make pallet funds == contributors reward
+	/// check easier and more efficient
+	type InitializedRewardAmount<T: Config> = StorageValue<_, BalanceOf<T>, ValueQuery>;
 
 	#[pallet::event]
 	#[pallet::generate_deposit(fn deposit_event)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -41,6 +41,8 @@ fn geneses() {
 			0,
 			5
 		));
+		assert_eq!(Crowdloan::total_contributors(), 5);
+
 		// accounts_payable
 		assert!(Crowdloan::accounts_payable(&1).is_some());
 		assert!(Crowdloan::accounts_payable(&2).is_some());
@@ -423,6 +425,7 @@ fn initialize_new_addresses_with_batch() {
 			))
 		]))
 		.dispatch(Origin::root()));
+		assert_eq!(Crowdloan::total_contributors(), 2);
 
 		// Batch calls always succeed. We just need to check the inner event
 		assert_ok!(
@@ -470,6 +473,7 @@ fn floating_point_arithmetic_works() {
 			))
 		]))
 		.dispatch(Origin::root()));
+		assert_eq!(Crowdloan::total_contributors(), 3);
 
 		assert_eq!(
 			Crowdloan::accounts_payable(&3).unwrap().claimed_reward,


### PR DESCRIPTION
This PR adds storage values for the total number of contributors and the initialized reward amount. The first one serves us a potential hint for weight calculation while the latter allows us to be more efficient when closing initialization, where we calculate `total_initialized_reward == Crowdloan funds`