### PR TITLE
Remove VestingPeriod to provide the ending block relay number at initialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,11 +339,17 @@ pub mod pallet {
 				Error::<T>::RewardVecAlreadyInitialized
 			);
 
+
 			// This implies single DB READ + WRITE the first time
 			// Subsequent batch calls to this function only imply a DB read
 			// Here we only read End Relay block, and this is the reason why
 			// I have made Init and End be in separate storages
 			if EndRelayBlock::<T>::get() == 0 {
+				// We need to make sure that it's greater than the init relay block
+				ensure!(
+					lease_ending_block > EndRelayBlock::<T>::get(),
+					Error::<T>::VestingPeriodNonValid
+				);
 				EndRelayBlock::<T>::put(lease_ending_block);
 			}
 
@@ -482,6 +488,8 @@ pub mod pallet {
 		RewardVecNotFullyInitializedYet,
 		/// Reward vec has already been initialized
 		RewardsDoNotMatchFund,
+		/// Provided vesting period is not valid
+		VestingPeriodNonValid,
 	}
 
 	#[pallet::genesis_config]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod pallet {
 		/// Percentage to be payed at initialization
 		#[pallet::constant]
 		type InitializationPayment: Get<Perbill>;
+		// Max number of contributors that can be inserted at once in initialize_reward_vec
 		#[pallet::constant]
 		type MaxInitContributors: Get<u32>;
 		/// The minimum contribution to which rewards will be paid.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,8 @@ pub mod pallet {
 		/// Percentage to be payed at initialization
 		#[pallet::constant]
 		type InitializationPayment: Get<Perbill>;
+		#[pallet::constant]
+		type MaxInitContributors: Get<u32>;
 		/// The minimum contribution to which rewards will be paid.
 		type MinimumReward: Get<BalanceOf<Self>>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
@@ -356,6 +358,7 @@ pub mod pallet {
 		}
 		/// Initialize the reward distribution storage. It shortcuts whenever an error is found
 		/// We can change this behavior to check this beforehand if we prefer
+		/// We check that the number of contributors inserted is less than T::MaxInitContributors::get()
 		#[pallet::weight(0)]
 		pub fn initialize_reward_vec(
 			origin: OriginFor<T>,
@@ -370,6 +373,12 @@ pub mod pallet {
 			ensure!(
 				initialized == false,
 				Error::<T>::RewardVecAlreadyInitialized
+			);
+
+			// Ensure we are below the max number of contributors
+			ensure!(
+				rewards.len() as u32 <= T::MaxInitContributors::get(),
+				Error::<T>::TooManyContributors
 			);
 
 			// What is the amount initialized so far?
@@ -496,6 +505,8 @@ pub mod pallet {
 		RewardVecNotFullyInitializedYet,
 		/// Reward vec has already been initialized
 		RewardsDoNotMatchFund,
+		/// Initialize_reward_vec received too many contributors
+		TooManyContributors,
 		/// Provided vesting period is not valid
 		VestingPeriodNonValid,
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub mod pallet {
 		/// The minimum contribution to which rewards will be paid.
 		type MinimumReward: Get<BalanceOf<Self>>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
-		type RewardCurrency: Currency<<Self as frame_system::Config>::AccountId>;
+		type RewardCurrency: Currency<Self::AccountId>;
 		// TODO What trait bounds do I need here? I think concretely we would
 		// be using MultiSigner? Or maybe MultiAccount? I copied these from frame_system
 		/// The AccountId type contributors used on the relay chain.
@@ -163,7 +163,7 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn associate_native_identity(
 			origin: OriginFor<T>,
-			reward_account: <T as frame_system::Config>::AccountId,
+			reward_account: T::AccountId,
 			relay_account: T::RelayChainAccountId,
 			proof: MultiSignature,
 		) -> DispatchResultWithPostInfo {
@@ -289,7 +289,7 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn update_reward_address(
 			origin: OriginFor<T>,
-			new_reward_account: <T as frame_system::Config>::AccountId,
+			new_reward_account: T::AccountId,
 		) -> DispatchResultWithPostInfo {
 			let signer = ensure_signed(origin)?;
 
@@ -363,11 +363,7 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn initialize_reward_vec(
 			origin: OriginFor<T>,
-			rewards: Vec<(
-				T::RelayChainAccountId,
-				Option<<T as frame_system::Config>::AccountId>,
-				BalanceOf<T>,
-			)>,
+			rewards: Vec<(T::RelayChainAccountId, Option<T::AccountId>, BalanceOf<T>)>,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 			let initialized = <Initialized<T>>::get();
@@ -468,7 +464,7 @@ pub mod pallet {
 
 	impl<T: Config> Pallet<T> {
 		/// The account ID that holds the Crowdloan's funds
-		pub fn account_id() -> <T as frame_system::Config>::AccountId {
+		pub fn account_id() -> T::AccountId {
 			PALLET_ID.into_account()
 		}
 		/// The Account Id's balance
@@ -538,7 +534,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn accounts_payable)]
 	pub type AccountsPayable<T: Config> =
-		StorageMap<_, Blake2_128Concat, <T as frame_system::Config>::AccountId, RewardInfo<T>>;
+		StorageMap<_, Blake2_128Concat, T::AccountId, RewardInfo<T>>;
 	#[pallet::storage]
 	#[pallet::getter(fn claimed_relay_chain_ids)]
 	pub type ClaimedRelayChainIds<T: Config> =
@@ -576,32 +572,25 @@ pub mod pallet {
 	#[pallet::generate_deposit(fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// The initial payment of InitializationPayment % was paid
-		InitialPaymentMade(<T as frame_system::Config>::AccountId, BalanceOf<T>),
+		InitialPaymentMade(T::AccountId, BalanceOf<T>),
 		/// Someone has proven they made a contribution and associated a native identity with it.
 		/// Data is the relay account,  native account and the total amount of _rewards_ that will be paid
-		NativeIdentityAssociated(
-			T::RelayChainAccountId,
-			<T as frame_system::Config>::AccountId,
-			BalanceOf<T>,
-		),
+		NativeIdentityAssociated(T::RelayChainAccountId, T::AccountId, BalanceOf<T>),
 		/// A contributor has claimed some rewards.
 		/// Data is the account getting paid and the amount of rewards paid.
-		RewardsPaid(<T as frame_system::Config>::AccountId, BalanceOf<T>),
+		RewardsPaid(T::AccountId, BalanceOf<T>),
 		/// A contributor has updated the reward address.
-		RewardAddressUpdated(
-			<T as frame_system::Config>::AccountId,
-			<T as frame_system::Config>::AccountId,
-		),
+		RewardAddressUpdated(T::AccountId, T::AccountId),
 		/// When initializing the reward vec an already initialized account was found
 		InitializedAlreadyInitializedAccount(
 			T::RelayChainAccountId,
-			Option<<T as frame_system::Config>::AccountId>,
+			Option<T::AccountId>,
 			BalanceOf<T>,
 		),
 		/// When initializing the reward vec an already initialized account was found
 		InitializedAccountWithNotEnoughContribution(
 			T::RelayChainAccountId,
-			Option<<T as frame_system::Config>::AccountId>,
+			Option<T::AccountId>,
 			BalanceOf<T>,
 		),
 	}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -120,6 +120,7 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
+	pub const TestMaxInitContributors: u32 = 8;
 	pub const TestMinimumReward: u128 = 0;
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
@@ -129,6 +130,7 @@ impl Config for Test {
 	type Event = Event;
 	type Initialized = TestInitialized;
 	type InitializationPayment = TestInitializationPayment;
+	type MaxInitContributors = TestMaxInitContributors;
 	type MinimumReward = TestMinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -120,7 +120,6 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
-	pub const TestVestingPeriod: u32 = 8;
 	pub const TestMinimumReward: u128 = 0;
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
@@ -133,7 +132,6 @@ impl Config for Test {
 	type MinimumReward = TestMinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
-	type VestingPeriod = TestVestingPeriod;
 }
 
 impl pallet_utility::Config for Test {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -460,7 +460,6 @@ fn initialize_new_addresses_with_batch() {
 		// Verify that the second ending block provider had no effect
 		assert_eq!(Crowdloan::end_relay_block(), init_block + VESTING);
 
-		assert_eq!(Crowdloan::total_contributors(), 2);
 		// Batch calls always succeed. We just need to check the inner event
 		assert_ok!(
 			mock::Call::Utility(UtilityCall::batch(vec![mock::Call::Crowdloan(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,6 +23,8 @@ use parity_scale_codec::Encode;
 use sp_core::Pair;
 use sp_runtime::MultiSignature;
 
+// Constant that reflects the desired vesting period for the tests
+// Most tests complete initialization passing initRelayBlock + VESTING as the endRelayBlock
 const VESTING: u32 = 8;
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -673,6 +673,25 @@ fn test_initialization_errors() {
 
 		let pot = Crowdloan::pot();
 
+		// Too many contributors
+		assert_noop!(
+			Crowdloan::initialize_reward_vec(
+				Origin::root(),
+				vec![
+					([1u8; 32].into(), Some(1), 1),
+					([2u8; 32].into(), Some(2), 1),
+					([3u8; 32].into(), Some(3), 1),
+					([4u8; 32].into(), Some(4), 1),
+					([5u8; 32].into(), Some(5), 1),
+					([6u8; 32].into(), Some(6), 1),
+					([7u8; 32].into(), Some(7), 1),
+					([8u8; 32].into(), Some(8), 1),
+					([9u8; 32].into(), Some(9), 1)
+				]
+			),
+			Error::<Test>::TooManyContributors
+		);
+
 		// Go beyond fund pot
 		assert_noop!(
 			Crowdloan::initialize_reward_vec(


### PR DESCRIPTION
This PR does a couple of things:
- Divides `initialize_reward_vec` in `initialize_reward_vec` and `complete_initialization`. Both are root dispatchables, the first inserts contributors while the latter performs the necessary checks and closes initialization.
- Removes the VestingPeriod type. Instead, the vesting period is calculated against a `lease_ending_block` parameter provided in the `complete_initialization` extrinsic.