### PR TITLE
Dust account handler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,14 +347,16 @@ pub mod pallet {
 
 			let current_initialized_rewards = InitializedRewardAmount::<T>::get();
 
+			let current_pot = Self::pot();
+
 			// There can't be more than 1 unit (10^-18) dust per reward so
 			ensure!(
-				current_initialized_rewards > Self::pot() - TotalContributors::<T>::get().into(),
+				current_initialized_rewards > current_pot - TotalContributors::<T>::get().into(),
 				Error::<T>::RewardsDoNotMatchFund
 			);
 
 			// Anything that does not match the pot should go to DustHandler
-			if Self::pot() > current_initialized_rewards {
+			if current_pot > current_initialized_rewards {
 				T::RewardCurrency::transfer(
 					&PALLET_ID.into_account(),
 					&T::DustHandler::get(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,20 @@ pub mod pallet {
 				total_contributors += 1;
 
 				if let Some(native_account) = native_account {
-					AccountsPayable::<T>::insert(native_account, reward_info);
+					if let Some(inserted_reward_info) = AccountsPayable::<T>::get(native_account) {
+						// the native account has already some rewards in, we add the new ones
+						AccountsPayable::<T>::insert(
+							native_account,
+							RewardInfo {
+								total_reward: inserted_reward_info.total_reward
+									+ reward_info.total_reward,
+								claimed_reward: inserted_reward_info.claimed_reward
+									+ reward_info.claimed_reward,
+							},
+						);
+					} else {
+						AccountsPayable::<T>::insert(native_account, reward_info);
+					}
 					ClaimedRelayChainIds::<T>::insert(relay_account, ());
 				} else {
 					UnassociatedContributions::<T>::insert(relay_account, reward_info);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,7 +519,6 @@ pub mod pallet {
 		RewardVecAlreadyInitialized,
 		/// Reward vec has not yet been fully initialized
 		RewardVecNotFullyInitializedYet,
-
 		/// Initialize_reward_vec received too many contributors
 		TooManyContributors,
 		/// Provided vesting period is not valid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,6 +347,12 @@ pub mod pallet {
 
 			let current_initialized_rewards = InitializedRewardAmount::<T>::get();
 
+			// There can't be more than 1 unit (10^-18) dust per reward so
+			ensure!(
+				current_initialized_rewards > Self::pot() - TotalContributors::<T>::get().into(),
+				Error::<T>::RewardsDoNotMatchFund
+			);
+
 			// Anything that does not match the pot should go to DustHandler
 			if Self::pot() > current_initialized_rewards {
 				T::RewardCurrency::transfer(
@@ -519,6 +525,8 @@ pub mod pallet {
 		RewardVecAlreadyInitialized,
 		/// Reward vec has not yet been fully initialized
 		RewardVecNotFullyInitializedYet,
+		/// Rewards should match funds of the pallet
+		RewardsDoNotMatchFund,
 		/// Initialize_reward_vec received too many contributors
 		TooManyContributors,
 		/// Provided vesting period is not valid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@ mod tests;
 pub mod pallet {
 
 	use cumulus_primitives_core::relay_chain;
-	use frame_support::traits::ExistenceRequirement::KeepAlive;
 	use frame_support::traits::WithdrawReasons;
 	use frame_support::{
 		dispatch::fmt::Debug,
@@ -125,10 +124,6 @@ pub mod pallet {
 	type BalanceOf<T> = <<T as Config>::RewardCurrency as Currency<
 		<T as frame_system::Config>::AccountId,
 	>>::Balance;
-
-	pub type NegativeImbalanceOf<T> = <<T as Config>::RewardCurrency as Currency<
-		<T as frame_system::Config>::AccountId,
-	>>::NegativeImbalance;
 
 	/// Stores info about the rewards owed as well as how much has been vested so far.
 	/// For a primer on this kind of design, see the recipe on compounding interest
@@ -366,7 +361,7 @@ pub mod pallet {
 					&PALLET_ID.into_account(),
 					to_burn,
 					WithdrawReasons::TRANSFER,
-					KeepAlive,
+					AllowDeath,
 				)
 				.map_err(|_| Error::<T>::ErrorBurningImbalance)?;
 			}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,7 @@ pub mod pallet {
 
 			let reward_difference = Self::pot().saturating_sub(current_initialized_rewards);
 
+			// Ensure the difference is not bigger than the total number of contributors
 			ensure!(
 				reward_difference < TotalContributors::<T>::get().into(),
 				Error::<T>::RewardsDoNotMatchFund

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -135,7 +135,6 @@ impl Config for Test {
 	type MinimumReward = TestMinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
-	type DustHandler = TestDustHandler;
 }
 
 impl pallet_utility::Config for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -124,6 +124,7 @@ parameter_types! {
 	pub const TestMinimumReward: u128 = 0;
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
+	pub const TestDustHandler: u64 = 10u64;
 }
 
 impl Config for Test {
@@ -134,6 +135,7 @@ impl Config for Test {
 	type MinimumReward = TestMinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
+	type DustHandler = TestDustHandler;
 }
 
 impl pallet_utility::Config for Test {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -124,7 +124,6 @@ parameter_types! {
 	pub const TestMinimumReward: u128 = 0;
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
-	pub const TestDustHandler: u64 = 10u64;
 }
 
 impl Config for Test {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -629,7 +629,7 @@ fn initialize_new_addresses_with_batch() {
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 9,
+					error: 8,
 					message: None,
 				},
 			),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -546,13 +546,20 @@ fn initialize_new_addresses_handle_dust() {
 				(pairs[1].public().into(), None, 999u32.into()),
 			]
 		));
+
+		let crowdloan_pot = Crowdloan::pot();
+		let previous_issuance = Balances::total_issuance();
 		assert_ok!(Crowdloan::complete_initialization(
 			Origin::root(),
 			init_block + VESTING
 		));
 
+		// We have burnt 1 unit
+		assert!(Crowdloan::pot() == crowdloan_pot - 1);
+		assert!(Balances::total_issuance() == previous_issuance - 1);
+
 		assert_eq!(Crowdloan::initialized(), true);
-		assert_eq!(Balances::free_balance(10), 1);
+		assert_eq!(Balances::free_balance(10), 0);
 	});
 }
 
@@ -622,7 +629,7 @@ fn initialize_new_addresses_with_batch() {
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 8,
+					error: 9,
 					message: None,
 				},
 			),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -530,6 +530,33 @@ fn initialize_new_addresses() {
 }
 
 #[test]
+fn initialize_new_addresses_not_matching_funds() {
+	empty().execute_with(|| {
+		// The init relay block gets inserted
+		roll_to(2);
+		// Insert contributors
+		let pairs = get_ed25519_pairs(2);
+		let init_block = Crowdloan::init_relay_block();
+		assert_ok!(Crowdloan::initialize_reward_vec(
+			Origin::root(),
+			vec![
+				([1u8; 32].into(), Some(1), 500u32.into()),
+				([2u8; 32].into(), Some(2), 500u32.into()),
+				(pairs[0].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 500u32.into()),
+			]
+		));
+		assert_ok!(Crowdloan::complete_initialization(
+			Origin::root(),
+			init_block + VESTING
+		));
+
+		assert_eq!(Crowdloan::initialized(), true);
+		assert_eq!(Balances::free_balance(10), 500);
+	});
+}
+
+#[test]
 fn initialize_new_addresses_with_batch() {
 	empty().execute_with(|| {
 		// This time should succeed trully
@@ -787,11 +814,6 @@ fn test_initialization_errors() {
 			Origin::root(),
 			vec![([1u8; 32].into(), Some(1), pot - 1)]
 		));
-
-		assert_noop!(
-			Crowdloan::complete_initialization(Origin::root(), init_block + VESTING),
-			Error::<Test>::RewardsDoNotMatchFund
-		);
 
 		// Fill rewards
 		assert_ok!(Crowdloan::initialize_reward_vec(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -564,13 +564,14 @@ fn initialize_new_addresses_not_matching_funds() {
 		// Insert contributors
 		let pairs = get_ed25519_pairs(2);
 		let init_block = Crowdloan::init_relay_block();
+		// Total supply is 2500.Lets ensure inserting 2495 is not working.
 		assert_ok!(Crowdloan::initialize_reward_vec(
 			Origin::root(),
 			vec![
 				([1u8; 32].into(), Some(1), 500u32.into()),
 				([2u8; 32].into(), Some(2), 500u32.into()),
 				(pairs[0].public().into(), None, 500u32.into()),
-				(pairs[1].public().into(), None, 500u32.into()),
+				(pairs[1].public().into(), None, 995u32.into()),
 			]
 		));
 		assert_noop!(


### PR DESCRIPTION
This PR adds a Dust account Handler that receives the dust from the initialization phase. This happens in the case after the initialization has completed the fund pot is slightly bigger than the initialized rewards