### PR TITLE
Overflow checker in initialize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,6 @@ pub mod pallet {
 				current_initialized_rewards += *reward - initial_payment;
 				total_contributors += 1;
 
-
 				if let Some(native_account) = native_account {
 					if let Some(inserted_reward_info) = AccountsPayable::<T>::get(native_account) {
 						// the native account has already some rewards in, we add the new ones
@@ -482,8 +481,10 @@ pub mod pallet {
 							native_account,
 							// It should be safe not to use saturating_add here, as we already checked before that these rewards do not overflow existing ones
 							RewardInfo {
-								total_reward: inserted_reward_info.total_reward + reward_info.total_reward,
-								claimed_reward: inserted_reward_info.claimed_reward + reward_info.claimed_reward,
+								total_reward: inserted_reward_info.total_reward
+									+ reward_info.total_reward,
+								claimed_reward: inserted_reward_info.claimed_reward
+									+ reward_info.claimed_reward,
 							},
 						);
 					} else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,7 +470,8 @@ pub mod pallet {
 					claimed_reward: initial_payment,
 				};
 
-				// It should be safe not to use saturating_add here, as we already checked before that these rewards do not overflow existing ones
+				// It should be safe not to use saturating_add here
+				// as we already checked before that these rewards do not overflow existing ones
 				current_initialized_rewards += *reward - initial_payment;
 				total_contributors += 1;
 
@@ -479,7 +480,8 @@ pub mod pallet {
 						// the native account has already some rewards in, we add the new ones
 						AccountsPayable::<T>::insert(
 							native_account,
-							// It should be safe not to use saturating_add here, as we already checked before that these rewards do not overflow existing ones
+							// It should be safe not to use saturating_add here
+							// as we already checked before that these rewards do not overflow existing ones
 							RewardInfo {
 								total_reward: inserted_reward_info.total_reward
 									+ reward_info.total_reward,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ pub mod pallet {
 
 			// Ensure we dont go over funds
 			ensure!(
-				current_initialized_rewards + incoming_rewards <= Self::pot(),
+				current_initialized_rewards.saturating_add(incoming_rewards) <= Self::pot(),
 				Error::<T>::BatchBeyondFundPot
 			);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@ pub mod pallet {
 			let incoming_rewards: BalanceOf<T> = rewards
 				.iter()
 				.fold(0u32.into(), |acc: BalanceOf<T>, (_, _, reward)| {
-					acc + *reward
+					acc.saturating_add(*reward)
 				});
 
 			// Ensure we dont go over funds
@@ -470,19 +470,20 @@ pub mod pallet {
 					claimed_reward: initial_payment,
 				};
 
+				// It should be safe not to use saturating_add here, as we already checked before that these rewards do not overflow existing ones
 				current_initialized_rewards += *reward - initial_payment;
 				total_contributors += 1;
+
 
 				if let Some(native_account) = native_account {
 					if let Some(inserted_reward_info) = AccountsPayable::<T>::get(native_account) {
 						// the native account has already some rewards in, we add the new ones
 						AccountsPayable::<T>::insert(
 							native_account,
+							// It should be safe not to use saturating_add here, as we already checked before that these rewards do not overflow existing ones
 							RewardInfo {
-								total_reward: inserted_reward_info.total_reward
-									+ reward_info.total_reward,
-								claimed_reward: inserted_reward_info.claimed_reward
-									+ reward_info.claimed_reward,
+								total_reward: inserted_reward_info.total_reward + reward_info.total_reward,
+								claimed_reward: inserted_reward_info.claimed_reward + reward_info.claimed_reward,
 							},
 						);
 					} else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -877,3 +877,27 @@ fn test_initialization_errors() {
 		);
 	});
 }
+
+
+#[test]
+fn test_assert_we_cannot_overflow_at_init() {
+	empty().execute_with(|| {
+		// The init relay block gets inserted
+		roll_to(2);
+		let init_block = Crowdloan::init_relay_block();
+
+		let pot = Crowdloan::pot();
+
+		// Too many contributors
+		assert_noop!(
+			Crowdloan::initialize_reward_vec(
+				Origin::root(),
+				vec![
+					([1u8; 32].into(), Some(1), 1),
+					([2u8; 32].into(), Some(2), u128::MAX),
+				]
+			),
+			Error::<Test>::TooManyContributors
+		);
+	});
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -878,7 +878,6 @@ fn test_initialization_errors() {
 	});
 }
 
-
 #[test]
 fn test_assert_we_cannot_overflow_at_init() {
 	empty().execute_with(|| {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -883,13 +883,17 @@ fn test_assert_we_cannot_overflow_at_init() {
 	empty().execute_with(|| {
 		// The init relay block gets inserted
 		roll_to(2);
-		// Too many contributors
+		assert_ok!(Crowdloan::initialize_reward_vec(
+			Origin::root(),
+			vec![([1u8; 32].into(), Some(1), 500u32.into()),]
+		));
+		// This should overflow
 		assert_noop!(
 			Crowdloan::initialize_reward_vec(
 				Origin::root(),
 				vec![
-					([1u8; 32].into(), Some(1), 1),
-					([2u8; 32].into(), Some(2), u128::MAX),
+					([2u8; 32].into(), Some(1), 1),
+					([3u8; 32].into(), Some(2), u128::MAX),
 				]
 			),
 			Error::<Test>::BatchBeyondFundPot

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -892,8 +892,8 @@ fn test_assert_we_cannot_overflow_at_init() {
 			Crowdloan::initialize_reward_vec(
 				Origin::root(),
 				vec![
-					([2u8; 32].into(), Some(1), 1),
-					([3u8; 32].into(), Some(2), u128::MAX),
+					([2u8; 32].into(), Some(2), 1),
+					([3u8; 32].into(), Some(3), u128::MAX),
 				]
 			),
 			Error::<Test>::BatchBeyondFundPot

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -884,10 +884,6 @@ fn test_assert_we_cannot_overflow_at_init() {
 	empty().execute_with(|| {
 		// The init relay block gets inserted
 		roll_to(2);
-		let init_block = Crowdloan::init_relay_block();
-
-		let pot = Crowdloan::pot();
-
 		// Too many contributors
 		assert_noop!(
 			Crowdloan::initialize_reward_vec(
@@ -897,7 +893,7 @@ fn test_assert_we_cannot_overflow_at_init() {
 					([2u8; 32].into(), Some(2), u128::MAX),
 				]
 			),
-			Error::<Test>::TooManyContributors
+			Error::<Test>::BatchBeyondFundPot
 		);
 	});
 }


### PR DESCRIPTION
The initialize_reward_vec did not have overflow checkers assuming this was democracy/sudo call based. I added these for consistency reasons with the rest of the pallet extrinsics