### PR TITLE
Associate relay address with reward address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub mod pallet {
 			<UnassociatedContributions<T>>::remove(&relay_account);
 
 			// Insert in mapping
-			ClaimedRelayChainIds::<T>::insert(&relay_account, ());
+			ClaimedRelayChainIds::<T>::insert(&relay_account, &reward_account);
 
 			// Emit Event
 			Self::deposit_event(Event::NativeIdentityAssociated(
@@ -488,7 +488,7 @@ pub mod pallet {
 					} else {
 						AccountsPayable::<T>::insert(native_account, reward_info);
 					}
-					ClaimedRelayChainIds::<T>::insert(relay_account, ());
+					ClaimedRelayChainIds::<T>::insert(relay_account, native_account);
 				} else {
 					UnassociatedContributions::<T>::insert(relay_account, reward_info);
 				}
@@ -576,7 +576,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn claimed_relay_chain_ids)]
 	pub type ClaimedRelayChainIds<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::RelayChainAccountId, ()>;
+		StorageMap<_, Blake2_128Concat, T::RelayChainAccountId, T::AccountId>;
 	#[pallet::storage]
 	#[pallet::getter(fn unassociated_contributions)]
 	pub type UnassociatedContributions<T: Config> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ pub mod pallet {
 			let current_address = ClaimedRelayChainIds::<T>::get(&relay_account)
 				.ok_or(Error::<T>::NoAssociatedClaim)?;
 
-			// This ensures the lease ending block is bigger than the init relay block
+			// This ensures the address is the one we have recorded
 			ensure!(current_address == signer, Error::<T>::NonValidContributor);
 
 			// Calculate the veted amount on demand.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -106,8 +106,7 @@ fn proving_assignation_works() {
 			Crowdloan::associate_native_identity(
 				Origin::signed(4),
 				4,
-				pairs[0].public().into(),
-				signature.clone()
+				vec![(pairs[0].public().into(), signature.clone())]
 			),
 			Error::<Test>::InvalidClaimSignature
 		);
@@ -115,8 +114,7 @@ fn proving_assignation_works() {
 		assert_ok!(Crowdloan::associate_native_identity(
 			Origin::signed(4),
 			3,
-			pairs[0].public().into(),
-			signature.clone()
+			vec![(pairs[0].public().into(), signature.clone())]
 		));
 
 		// now three is payable
@@ -131,8 +129,7 @@ fn proving_assignation_works() {
 		assert_ok!(Crowdloan::associate_native_identity(
 			Origin::signed(4),
 			5,
-			pairs[0].public().into(),
-			signature_2
+			vec![(pairs[0].public().into(), signature_2.clone())]
 		),);
 
 		// now five is payable
@@ -148,8 +145,7 @@ fn proving_assignation_works() {
 			Crowdloan::associate_native_identity(
 				Origin::signed(4),
 				5,
-				pairs[3].public().into(),
-				non_contributed_signature
+				vec![(pairs[3].public().into(), non_contributed_signature.clone())]
 			),
 			Error::<Test>::NoAssociatedClaim
 		);
@@ -158,8 +154,8 @@ fn proving_assignation_works() {
 			crate::Event::InitialPaymentMade(1, 100),
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::InitialPaymentMade(3, 100),
-			crate::Event::NativeIdentityAssociated(pairs[0].public().into(), 3, 500),
-			crate::Event::NativeIdentityAssociated(pairs[0].public().into(), 5, 500),
+			crate::Event::NativeIdentityAssociated(3, 500),
+			crate::Event::NativeIdentityAssociated(5, 500),
 		];
 		assert_eq!(events(), expected);
 	});
@@ -366,8 +362,9 @@ fn paying_late_joiner_works() {
 		assert_ok!(Crowdloan::associate_native_identity(
 			Origin::signed(4),
 			3,
+			vec![(
 			pairs[0].public().into(),
-			signature.clone()
+			signature.clone())]
 		));
 		assert_ok!(Crowdloan::claim(Origin::signed(3)));
 		assert_eq!(Crowdloan::accounts_payable(&3).unwrap().claimed_reward, 500);
@@ -375,7 +372,7 @@ fn paying_late_joiner_works() {
 			crate::Event::InitialPaymentMade(1, 100),
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::InitialPaymentMade(3, 100),
-			crate::Event::NativeIdentityAssociated(pairs[0].public().into(), 3, 500),
+			crate::Event::NativeIdentityAssociated(3, 500),
 			crate::Event::RewardsPaid(3, 400),
 		];
 		assert_eq!(events(), expected);
@@ -672,7 +669,7 @@ fn initialize_new_addresses_with_batch() {
 				0,
 				DispatchError::Module {
 					index: 2,
-					error: 8,
+					error: 7,
 					message: None,
 				},
 			),
@@ -960,8 +957,7 @@ fn assignation_with_existing_key_works() {
 		assert_ok!(Crowdloan::associate_native_identity(
 			Origin::signed(1),
 			1,
-			pairs[0].public().into(),
-			signature.clone()
+			vec![(pairs[0].public().into(), signature.clone())]
 		));
 
 		roll_to(5);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -58,8 +58,8 @@ fn geneses() {
 		assert!(Crowdloan::accounts_payable(&5).is_none());
 
 		// claimed address existence
-		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
-		assert!(Crowdloan::claimed_relay_chain_ids(&[2u8; 32]).is_some());
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 1);
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[2u8; 32]).unwrap(), 2);
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).is_none());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[1].public().as_array_ref()).is_none());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[2].public().as_array_ref()).is_none());
@@ -128,7 +128,10 @@ fn proving_assignation_works() {
 		// now three is payable
 		assert!(Crowdloan::accounts_payable(&3).is_some());
 		assert!(Crowdloan::unassociated_contributions(pairs[0].public().as_array_ref()).is_none());
-		assert!(Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).is_some());
+		assert_eq!(
+			Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).unwrap(),
+			3
+		);
 
 		let expected = vec![
 			crate::Event::InitialPaymentMade(1, 100),
@@ -386,7 +389,13 @@ fn update_address_works() {
 			Crowdloan::claim(Origin::signed(8)),
 			Error::<Test>::NoAssociatedClaim
 		);
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
+		assert_ok!(Crowdloan::update_reward_address(
+			Origin::signed(1),
+			8,
+			[1u8; 32].into()
+		));
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 8);
+
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 200);
 		roll_to(6);
 		assert_ok!(Crowdloan::claim(Origin::signed(8)));
@@ -396,7 +405,7 @@ fn update_address_works() {
 			crate::Event::InitialPaymentMade(1, 100),
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::RewardsPaid(1, 100),
-			crate::Event::RewardAddressUpdated(1, 8),
+			crate::Event::RewardAddressUpdated([1u8; 32].into(), 1, 8),
 			crate::Event::RewardsPaid(8, 100),
 		];
 		assert_eq!(events(), expected);
@@ -429,7 +438,13 @@ fn update_address_with_existing_address_works() {
 		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_ok!(Crowdloan::claim(Origin::signed(2)));
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
+		assert_ok!(Crowdloan::update_reward_address(
+			Origin::signed(1),
+			2,
+			[1u8; 32].into()
+		));
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 2);
+
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(1)),
@@ -443,7 +458,7 @@ fn update_address_with_existing_address_works() {
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::RewardsPaid(1, 100),
 			crate::Event::RewardsPaid(2, 100),
-			crate::Event::RewardAddressUpdated(1, 2),
+			crate::Event::RewardAddressUpdated([1u8; 32].into(), 1, 2),
 			crate::Event::RewardsPaid(2, 200),
 		];
 		assert_eq!(events(), expected);
@@ -477,7 +492,13 @@ fn update_address_with_existing_with_multi_address_works() {
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 
 		// We make sure all rewards go to the new address
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
+		assert_ok!(Crowdloan::update_reward_address(
+			Origin::signed(1),
+			2,
+			[1u8; 32].into()
+		));
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 2);
+
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().total_reward, 1000);
 

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -82,12 +82,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	fn update_reward_address() -> Weight {
 		(59_051_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 	fn associate_native_identity() -> Weight {
 		(152_997_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
+			.saturating_add(T::DbWeight::get().reads(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
 }
@@ -115,12 +115,12 @@ impl WeightInfo for () {
 	}
 	fn update_reward_address() -> Weight {
 		(59_051_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
+			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
 	fn associate_native_identity() -> Weight {
 		(152_997_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
+			.saturating_add(RocksDbWeight::get().reads(9 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
 }


### PR DESCRIPTION
This PR: 
- modifies the storage to include a mapping from relay to para address
- modifies the update_reward_address to accept the relay chain account as an argument to be able to track correctly reward changes
- allows changing the reward address with a relay chain signature