### PR TITLE
Storage changes to support key changing

### DIFF
--- a/src/benchmarks.rs
+++ b/src/benchmarks.rs
@@ -301,10 +301,10 @@ benchmarks! {
 		// The new user
 		let new_user = create_funded_user::<T>("user", SEED+1, 0u32.into());
 
-	}:  _(RawOrigin::Signed(caller.clone()), new_user.clone(), relay_account.clone())
+	}:  _(RawOrigin::Signed(caller.clone()), new_user.clone())
 	verify {
 		assert_eq!(Pallet::<T>::accounts_payable(&new_user).unwrap().total_reward, (100u32.into()));
-		assert_eq!(Pallet::<T>::claimed_relay_chain_ids(&relay_account).unwrap(), new_user);
+		assert!(Pallet::<T>::claimed_relay_chain_ids(&relay_account).is_some());
 	}
 
 	associate_native_identity {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub mod pallet {
 			<UnassociatedContributions<T>>::remove(&relay_account);
 
 			// Insert in mapping
-			ClaimedRelayChainIds::<T>::insert(&relay_account, ());
+			ClaimedRelayChainIds::<T>::insert(&relay_account, &reward_account);
 
 			// Emit Event
 			Self::deposit_event(Event::NativeIdentityAssociated(
@@ -488,7 +488,7 @@ pub mod pallet {
 					} else {
 						AccountsPayable::<T>::insert(native_account, reward_info);
 					}
-					ClaimedRelayChainIds::<T>::insert(relay_account, ());
+					ClaimedRelayChainIds::<T>::insert(relay_account, native_account);
 				} else {
 					UnassociatedContributions::<T>::insert(relay_account, reward_info);
 				}
@@ -576,7 +576,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn claimed_relay_chain_ids)]
 	pub type ClaimedRelayChainIds<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::RelayChainAccountId, ()>;
+		StorageMap<_, Blake2_128Concat, T::RelayChainAccountId, T::AccountId>;
 	#[pallet::storage]
 	#[pallet::getter(fn unassociated_contributions)]
 	pub type UnassociatedContributions<T: Config> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,10 @@ pub mod pallet {
 	use sp_runtime::traits::{AccountIdConversion, Saturating, Verify};
 	use sp_runtime::{MultiSignature, Perbill};
 	use sp_std::vec::Vec;
+	use sp_std::vec;
 
-	/// The Author Filter pallet
 	#[pallet::pallet]
+	// The crowdloan rewards pallet
 	pub struct Pallet<T>(PhantomData<T>);
 
 	pub const PALLET_ID: PalletId = PalletId(*b"Crowdloa");
@@ -314,7 +315,8 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 
 			// Calculate the veted amount on demand.
-			let info = AccountsPayable::<T>::get(&signer).ok_or(Error::<T>::NoAssociatedClaim)?;
+			let info =
+				AccountsPayable::<T>::get(&signer).ok_or(Error::<T>::NoAssociatedClaim)?;
 
 			// For now I prefer that we dont support providing an existing account here
 			ensure!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,8 +558,6 @@ pub mod pallet {
 		TooManyContributors,
 		/// Provided vesting period is not valid
 		VestingPeriodNonValid,
-		/// Provided a non valid contributor
-		NonValidContributor,
 	}
 
 	#[pallet::genesis_config]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,12 @@ pub mod pallet {
 				Error::<T>::AlreadyAssociated
 			);
 
+			// For now I prefer that we dont support providing an existing account here
+			ensure!(
+				AccountsPayable::<T>::get(&reward_account).is_none(),
+				Error::<T>::AlreadyAssociated
+			);
+
 			// Upon error this should check the relay chain state in this case
 			let mut reward_info = UnassociatedContributions::<T>::get(&relay_account)
 				.ok_or(Error::<T>::NoAssociatedClaim)?;
@@ -218,16 +224,6 @@ pub mod pallet {
 			));
 
 			reward_info.claimed_reward = first_payment;
-
-			// We update if there is such an account already with rewards
-			if let Some(info_existing_account) = AccountsPayable::<T>::get(&reward_account) {
-				reward_info.total_reward = reward_info
-					.total_reward
-					.saturating_add(info_existing_account.total_reward);
-				reward_info.claimed_reward = reward_info
-					.claimed_reward
-					.saturating_add(info_existing_account.claimed_reward);
-			}
 
 			// Insert on payable
 			AccountsPayable::<T>::insert(&reward_account, &reward_info);
@@ -318,17 +314,14 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 
 			// Calculate the veted amount on demand.
-			let mut info =
+			let info =
 				AccountsPayable::<T>::get(&signer).ok_or(Error::<T>::NoAssociatedClaim)?;
 
-			if let Some(info_existing_account) = AccountsPayable::<T>::get(&new_reward_account) {
-				info.total_reward = info
-					.total_reward
-					.saturating_add(info_existing_account.total_reward);
-				info.claimed_reward = info
-					.claimed_reward
-					.saturating_add(info_existing_account.claimed_reward);
-			}
+			// For now I prefer that we dont support providing an existing account here
+			ensure!(
+				AccountsPayable::<T>::get(&new_reward_account).is_none(),
+				Error::<T>::AlreadyAssociated
+			);
 
 			// Remove previous rewarded account
 			AccountsPayable::<T>::remove(&signer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,8 +314,7 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 
 			// Calculate the veted amount on demand.
-			let info =
-				AccountsPayable::<T>::get(&signer).ok_or(Error::<T>::NoAssociatedClaim)?;
+			let info = AccountsPayable::<T>::get(&signer).ok_or(Error::<T>::NoAssociatedClaim)?;
 
 			// For now I prefer that we dont support providing an existing account here
 			ensure!(
@@ -501,7 +500,6 @@ pub mod pallet {
 						// First reward association
 						AccountsPayable::<T>::insert(native_account, reward_info);
 					}
-
 					ClaimedRelayChainIds::<T>::insert(relay_account, ());
 				} else {
 					UnassociatedContributions::<T>::insert(relay_account, reward_info);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,7 +470,7 @@ pub mod pallet {
 				};
 
 				// We need to calculate the vesting based on the relay block number
-				let reward_info = RewardInfo {
+				let mut reward_info = RewardInfo {
 					total_reward: *reward,
 					claimed_reward: initial_payment,
 					contributed_relay_addresses: vec![relay_account.clone()],
@@ -485,7 +485,7 @@ pub mod pallet {
 					{
 						inserted_reward_info
 							.contributed_relay_addresses
-							.push(relay_account.clone());
+							.append(&mut reward_info.contributed_relay_addresses);
 						// the native account has already some rewards in, we add the new ones
 						AccountsPayable::<T>::insert(
 							native_account,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -388,8 +388,6 @@ fn update_address_works() {
 		);
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
 
-		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
-
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 200);
 		roll_to(6);
 		assert_ok!(Crowdloan::claim(Origin::signed(8)));
@@ -467,7 +465,6 @@ fn update_address_with_existing_with_multi_address_works() {
 		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
 
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
-		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().total_reward, 1000);
 
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(1)),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -430,7 +430,10 @@ fn update_address_with_existing_address_fails() {
 		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_ok!(Crowdloan::claim(Origin::signed(2)));
-		assert_noop!(Crowdloan::update_reward_address(Origin::signed(1), 2), Error::<Test>::AlreadyAssociated);
+		assert_noop!(
+			Crowdloan::update_reward_address(Origin::signed(1), 2),
+			Error::<Test>::AlreadyAssociated
+		);
 	});
 }
 
@@ -461,8 +464,7 @@ fn update_address_with_existing_with_multi_address_works() {
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 
 		// We make sure all rewards go to the new address
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2,));
-		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
+		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
 
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -58,8 +58,8 @@ fn geneses() {
 		assert!(Crowdloan::accounts_payable(&5).is_none());
 
 		// claimed address existence
-		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 1);
-		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[2u8; 32]).unwrap(), 2);
+		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
+		assert!(Crowdloan::claimed_relay_chain_ids(&[2u8; 32]).is_some());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).is_none());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[1].public().as_array_ref()).is_none());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[2].public().as_array_ref()).is_none());
@@ -128,10 +128,7 @@ fn proving_assignation_works() {
 		// now three is payable
 		assert!(Crowdloan::accounts_payable(&3).is_some());
 		assert!(Crowdloan::unassociated_contributions(pairs[0].public().as_array_ref()).is_none());
-		assert_eq!(
-			Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).unwrap(),
-			3
-		);
+		assert!(Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).is_some());
 
 		let expected = vec![
 			crate::Event::InitialPaymentMade(1, 100),
@@ -389,12 +386,9 @@ fn update_address_works() {
 			Crowdloan::claim(Origin::signed(8)),
 			Error::<Test>::NoAssociatedClaim
 		);
-		assert_ok!(Crowdloan::update_reward_address(
-			Origin::signed(1),
-			8,
-			[1u8; 32].into()
-		));
-		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 8);
+		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
+
+		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
 
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 200);
 		roll_to(6);
@@ -405,7 +399,7 @@ fn update_address_works() {
 			crate::Event::InitialPaymentMade(1, 100),
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::RewardsPaid(1, 100),
-			crate::Event::RewardAddressUpdated([1u8; 32].into(), 1, 8),
+			crate::Event::RewardAddressUpdated(1, 8),
 			crate::Event::RewardsPaid(8, 100),
 		];
 		assert_eq!(events(), expected);
@@ -438,12 +432,9 @@ fn update_address_with_existing_address_works() {
 		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_ok!(Crowdloan::claim(Origin::signed(2)));
-		assert_ok!(Crowdloan::update_reward_address(
-			Origin::signed(1),
-			2,
-			[1u8; 32].into()
-		));
-		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 2);
+		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
+
+		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
 
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_noop!(
@@ -458,7 +449,7 @@ fn update_address_with_existing_address_works() {
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::RewardsPaid(1, 100),
 			crate::Event::RewardsPaid(2, 100),
-			crate::Event::RewardAddressUpdated([1u8; 32].into(), 1, 2),
+			crate::Event::RewardAddressUpdated(1, 2),
 			crate::Event::RewardsPaid(2, 200),
 		];
 		assert_eq!(events(), expected);
@@ -492,12 +483,8 @@ fn update_address_with_existing_with_multi_address_works() {
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 
 		// We make sure all rewards go to the new address
-		assert_ok!(Crowdloan::update_reward_address(
-			Origin::signed(1),
-			2,
-			[1u8; 32].into()
-		));
-		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 2);
+		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2,));
+		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
 
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().total_reward, 1000);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -488,6 +488,7 @@ fn update_address_with_existing_with_multi_address_works() {
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().total_reward, 1000);
+		
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(1)),
 			Error::<Test>::NoAssociatedClaim

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -77,7 +77,6 @@ fn geneses() {
 fn proving_assignation_works() {
 	let pairs = get_ed25519_pairs(3);
 	let signature: MultiSignature = pairs[0].sign(&3u64.encode()).into();
-
 	empty().execute_with(|| {
 		// Insert contributors
 		let pairs = get_ed25519_pairs(3);
@@ -116,7 +115,6 @@ fn proving_assignation_works() {
 			),
 			Error::<Test>::InvalidClaimSignature
 		);
-
 		// Signature is right, prove passes
 		assert_ok!(Crowdloan::associate_native_identity(
 			Origin::signed(4),
@@ -411,7 +409,6 @@ fn update_address_works() {
 			Error::<Test>::NoAssociatedClaim
 		);
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
-
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 200);
 		roll_to(6);
 		assert_ok!(Crowdloan::claim(Origin::signed(8)));
@@ -489,9 +486,8 @@ fn update_address_with_existing_with_multi_address_works() {
 
 		// We make sure all rewards go to the new address
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
-
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
-
+		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().total_reward, 1000);
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(1)),
 			Error::<Test>::NoAssociatedClaim

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -488,7 +488,7 @@ fn update_address_with_existing_with_multi_address_works() {
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().total_reward, 1000);
-		
+
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(1)),
 			Error::<Test>::NoAssociatedClaim

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -407,7 +407,7 @@ fn update_address_works() {
 }
 
 #[test]
-fn update_address_with_existing_address_works() {
+fn update_address_with_existing_address_fails() {
 	empty().execute_with(|| {
 		// Insert contributors
 		let pairs = get_ed25519_pairs(3);
@@ -432,27 +432,7 @@ fn update_address_with_existing_address_works() {
 		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_ok!(Crowdloan::claim(Origin::signed(2)));
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
-
-		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
-
-		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
-		assert_noop!(
-			Crowdloan::claim(Origin::signed(1)),
-			Error::<Test>::NoAssociatedClaim
-		);
-		roll_to(6);
-		assert_ok!(Crowdloan::claim(Origin::signed(2)));
-		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 600);
-		let expected = vec![
-			crate::Event::InitialPaymentMade(1, 100),
-			crate::Event::InitialPaymentMade(2, 100),
-			crate::Event::RewardsPaid(1, 100),
-			crate::Event::RewardsPaid(2, 100),
-			crate::Event::RewardAddressUpdated(1, 2),
-			crate::Event::RewardsPaid(2, 200),
-		];
-		assert_eq!(events(), expected);
+		assert_noop!(Crowdloan::update_reward_address(Origin::signed(1), 2), Error::<Test>::AlreadyAssociated);
 	});
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -58,8 +58,8 @@ fn geneses() {
 		assert!(Crowdloan::accounts_payable(&5).is_none());
 
 		// claimed address existence
-		assert!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).is_some());
-		assert!(Crowdloan::claimed_relay_chain_ids(&[2u8; 32]).is_some());
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 1);
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[2u8; 32]).unwrap(), 2);
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).is_none());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[1].public().as_array_ref()).is_none());
 		assert!(Crowdloan::claimed_relay_chain_ids(pairs[2].public().as_array_ref()).is_none());
@@ -128,7 +128,10 @@ fn proving_assignation_works() {
 		// now three is payable
 		assert!(Crowdloan::accounts_payable(&3).is_some());
 		assert!(Crowdloan::unassociated_contributions(pairs[0].public().as_array_ref()).is_none());
-		assert!(Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).is_some());
+		assert_eq!(
+			Crowdloan::claimed_relay_chain_ids(pairs[0].public().as_array_ref()).unwrap(),
+			3
+		);
 
 		let expected = vec![
 			crate::Event::InitialPaymentMade(1, 100),
@@ -386,7 +389,13 @@ fn update_address_works() {
 			Crowdloan::claim(Origin::signed(8)),
 			Error::<Test>::NoAssociatedClaim
 		);
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
+		assert_ok!(Crowdloan::update_reward_address(
+			Origin::signed(1),
+			8,
+			[1u8; 32].into()
+		));
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 8);
+
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 200);
 		roll_to(6);
 		assert_ok!(Crowdloan::claim(Origin::signed(8)));
@@ -396,7 +405,7 @@ fn update_address_works() {
 			crate::Event::InitialPaymentMade(1, 100),
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::RewardsPaid(1, 100),
-			crate::Event::RewardAddressUpdated(1, 8),
+			crate::Event::RewardAddressUpdated([1u8; 32].into(), 1, 8),
 			crate::Event::RewardsPaid(8, 100),
 		];
 		assert_eq!(events(), expected);
@@ -429,7 +438,13 @@ fn update_address_with_existing_address_works() {
 		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_ok!(Crowdloan::claim(Origin::signed(2)));
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
+		assert_ok!(Crowdloan::update_reward_address(
+			Origin::signed(1),
+			2,
+			[1u8; 32].into()
+		));
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 2);
+
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(1)),
@@ -443,7 +458,7 @@ fn update_address_with_existing_address_works() {
 			crate::Event::InitialPaymentMade(2, 100),
 			crate::Event::RewardsPaid(1, 100),
 			crate::Event::RewardsPaid(2, 100),
-			crate::Event::RewardAddressUpdated(1, 2),
+			crate::Event::RewardAddressUpdated([1u8; 32].into(), 1, 2),
 			crate::Event::RewardsPaid(2, 200),
 		];
 		assert_eq!(events(), expected);
@@ -477,7 +492,13 @@ fn update_address_with_existing_with_multi_address_works() {
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 
 		// We make sure all rewards go to the new address
-		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 2));
+		assert_ok!(Crowdloan::update_reward_address(
+			Origin::signed(1),
+			2,
+			[1u8; 32].into()
+		));
+		assert_eq!(Crowdloan::claimed_relay_chain_ids(&[1u8; 32]).unwrap(), 2);
+
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().claimed_reward, 400);
 		assert_eq!(Crowdloan::accounts_payable(&2).unwrap().total_reward, 1000);
 

--- a/src/weights.rs
+++ b/src/weights.rs
@@ -64,7 +64,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn initialize_reward_vec(x: u32) -> Weight {
 		(50_432_000 as Weight)
 			// Standard Error: 21_000
-			.saturating_add((72_298_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add((143_109_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(x as Weight)))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
@@ -87,7 +87,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	fn associate_native_identity() -> Weight {
 		(152_997_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
+			.saturating_add(T::DbWeight::get().reads(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
 }
@@ -97,7 +97,7 @@ impl WeightInfo for () {
 	fn initialize_reward_vec(x: u32) -> Weight {
 		(50_432_000 as Weight)
 			// Standard Error: 21_000
-			.saturating_add((72_298_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add((143_109_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
 			.saturating_add(RocksDbWeight::get().reads((4 as Weight).saturating_mul(x as Weight)))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
@@ -120,7 +120,7 @@ impl WeightInfo for () {
 	}
 	fn associate_native_identity() -> Weight {
 		(152_997_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
+			.saturating_add(RocksDbWeight::get().reads(9 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
 }


### PR DESCRIPTION
This PR introduces one storage change:

- `RewardInfo` now contains `contributed_relay_addresses`, which contains the relay addresses that specified the same native_reward as memo. This should serve in the future to allow for key changes if all/some of these `contributed_relay_addresses` provide a proof for that
