### PR TITLE
Completely remove cumulus (dev-)dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,23 +10,23 @@ parity-scale-codec = { version = "2.1.1", default-features = false}
 serde = { version = "1.0.101", optional = true, features = ["derive"], default-features = false }
 log = { version = "0.4", default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false, optional = true }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9" }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend", "alloc"], optional = true }
-sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
+sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ sp-io = { git = "https://github.com/paritytech/substrate", default-features = fa
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.9", default-features = false, optional = true }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend", "alloc"], optional = true }
 sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.9" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
 
 [features]
 default = ["std"]
@@ -43,9 +43,6 @@ std = [
     "log/std",
     "sp-std/std",
     "sp-io/std",
-    "cumulus-pallet-parachain-system/std",
-    "cumulus-primitives-core/std",
-    "cumulus-primitives-parachain-inherent/std",
 ]
 runtime-benchmarks = [
     "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "p
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false, optional = true }
 cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend", "alloc"], optional = true }
@@ -46,7 +45,6 @@ std = [
     "sp-io/std",
     "cumulus-pallet-parachain-system/std",
     "cumulus-primitives-core/std",
-    "nimbus-primitives/std",
     "cumulus-primitives-parachain-inherent/std",
 ]
 runtime-benchmarks = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,6 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend", "alloc"], optional = true }
 sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.9", optional = true }
 
-[dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.9" }
-
 [features]
 default = ["std"]
 std = [

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-02-21"
+channel = "nightly-2021-08-01"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,10 +82,10 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_core::crypto::AccountId32;
-	use sp_runtime::traits::{AccountIdConversion, AtLeast32BitUnsigned, BlockNumberProvider, Saturating, Verify};
+	use sp_runtime::traits::{AccountIdConversion, AtLeast32BitUnsigned, Saturating, Verify};
 	use sp_runtime::{MultiSignature, Perbill};
-	use sp_std::vec::Vec;
 	use sp_std::vec;
+	use sp_std::vec::Vec;
 
 	#[pallet::pallet]
 	// The crowdloan rewards pallet
@@ -94,6 +94,26 @@ pub mod pallet {
 	pub const PALLET_ID: PalletId = PalletId(*b"Crowdloa");
 
 	pub struct RelayChainBeacon<T>(PhantomData<T>);
+
+	/// Something that can provide a block number
+	pub trait BlockProvider {
+		/// Type of `BlockNumber` to provide.
+		type BlockNumber: parity_scale_codec::Codec + Clone + Ord + Eq + AtLeast32BitUnsigned;
+
+		/// Returns the current block number.
+		///
+		/// Provides an abstraction over an arbitrary way of providing the
+		/// current block number.
+		///
+		fn current_block_number() -> Self::BlockNumber;
+
+		/// Utility function only to be used in benchmarking scenarios, to be implemented optionally,
+		/// else a noop.
+		///
+		/// It allows for setting the block number that will later be fetched
+		#[cfg(any(feature = "runtime-benchmarks", test))]
+		fn set_block_number(_block: Self::BlockNumber) {}
+	}
 
 	/// Configuration trait of this pallet.
 	#[pallet::config]
@@ -117,16 +137,13 @@ pub mod pallet {
 			//TODO these AccountId32 bounds feel a little extraneous. I wonder if we can remove them.
 			+ Into<AccountId32>
 			+ From<AccountId32>;
-		
+
 		/// The type that will be used to track vesting progress
-		type VestingBlockNumber: AtLeast32BitUnsigned
-		+ Parameter
-		+ Default
-		+ Into<BalanceOf<Self>>;
+		type VestingBlockNumber: AtLeast32BitUnsigned + Parameter + Default + Into<BalanceOf<Self>>;
 
 		/// The notion of time that will be used for vesting. Probably
 		/// either the relay chain or sovereign chain block number.
-		type VestingBlockProvider: BlockNumberProvider<BlockNumber = Self::VestingBlockNumber>;
+		type VestingBlockProvider: BlockProvider<BlockNumber = Self::VestingBlockNumber>;
 
 		type WeightInfo: WeightInfo;
 	}
@@ -312,8 +329,7 @@ pub mod pallet {
 			let signer = ensure_signed(origin)?;
 
 			// Calculate the veted amount on demand.
-			let info =
-				AccountsPayable::<T>::get(&signer).ok_or(Error::<T>::NoAssociatedClaim)?;
+			let info = AccountsPayable::<T>::get(&signer).ok_or(Error::<T>::NoAssociatedClaim)?;
 
 			// For now I prefer that we dont support providing an existing account here
 			ensure!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,14 +76,13 @@ pub mod pallet {
 	use crate::weights::WeightInfo;
 	use frame_support::traits::WithdrawReasons;
 	use frame_support::{
-		dispatch::fmt::Debug,
 		pallet_prelude::*,
 		traits::{Currency, ExistenceRequirement::AllowDeath},
 		PalletId,
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_core::crypto::AccountId32;
-	use sp_runtime::traits::{AccountIdConversion, BlockNumberProvider, Saturating, Verify};
+	use sp_runtime::traits::{AccountIdConversion, AtLeast32BitUnsigned, BlockNumberProvider, Saturating, Verify};
 	use sp_runtime::{MultiSignature, Perbill};
 	use sp_std::vec::Vec;
 	use sp_std::vec;
@@ -113,26 +112,16 @@ pub mod pallet {
 		type MinimumReward: Get<BalanceOf<Self>>;
 		/// The currency in which the rewards will be paid (probably the parachain native currency)
 		type RewardCurrency: Currency<Self::AccountId>;
-		// TODO What trait bounds do I need here? I think concretely we would
-		// be using MultiSigner? Or maybe MultiAccount? I copied these from frame_system
 		/// The AccountId type contributors used on the relay chain.
 		type RelayChainAccountId: Parameter
-			+ Member
-			+ MaybeSerializeDeserialize
-			+ Ord
-			+ Default
-			+ Debug
+			//TODO these AccountId32 bounds feel a little extraneous. I wonder if we can remove them.
 			+ Into<AccountId32>
 			+ From<AccountId32>;
 		
-		//TODO do we need at least 32 bit unsigned
 		/// The type that will be used to track vesting progress
-		type VestingBlockNumber: sp_runtime::traits::AtLeast32BitUnsigned + Parameter
-		+ Member
-		+ MaybeSerializeDeserialize
-		+ Ord
+		type VestingBlockNumber: AtLeast32BitUnsigned
+		+ Parameter
 		+ Default
-		+ Debug
 		+ Into<BalanceOf<Self>>;
 
 		/// The notion of time that will be used for vesting. Probably

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,8 @@ pub mod pallet {
 
 		/// The notion of time that will be used for vesting. Probably
 		/// either the relay chain or sovereign chain block number.
+		/// This should change to use sp_runtime::traits::BlockNumberProvider once
+		/// https://github.com/paritytech/substrate/pull/9668  is merged
 		type VestingBlockProvider: BlockProvider<BlockNumber = Self::VestingBlockNumber>;
 
 		type WeightInfo: WeightInfo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub mod pallet {
 	pub struct RelayChainBeacon<T>(PhantomData<T>);
 
 	/// Something that can provide a block number
+	/// To be removed once https://github.com/paritytech/substrate/pull/9668 is merged
 	pub trait BlockProvider {
 		/// Type of `BlockNumber` to provide.
 		type BlockNumber: parity_scale_codec::Codec + Clone + Ord + Eq + AtLeast32BitUnsigned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@ pub mod weights;
 pub mod pallet {
 
 	use crate::weights::WeightInfo;
-	use cumulus_primitives_core::relay_chain;
 	use frame_support::traits::WithdrawReasons;
 	use frame_support::{
 		dispatch::fmt::Debug,
@@ -84,7 +83,7 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_core::crypto::AccountId32;
-	use sp_runtime::traits::{AccountIdConversion, Saturating, Verify};
+	use sp_runtime::traits::{AccountIdConversion, BlockNumberProvider, Saturating, Verify};
 	use sp_runtime::{MultiSignature, Perbill};
 	use sp_std::vec::Vec;
 	use sp_std::vec;
@@ -99,7 +98,7 @@ pub mod pallet {
 
 	/// Configuration trait of this pallet.
 	#[pallet::config]
-	pub trait Config: cumulus_pallet_parachain_system::Config + frame_system::Config {
+	pub trait Config: frame_system::Config {
 		/// The overarching event type
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Checker for the reward vec, is it initalized already?
@@ -125,6 +124,20 @@ pub mod pallet {
 			+ Debug
 			+ Into<AccountId32>
 			+ From<AccountId32>;
+		
+		//TODO do we need at least 32 bit unsigned
+		/// The type that will be used to track vesting progress
+		type VestingBlockNumber: sp_runtime::traits::AtLeast32BitUnsigned + Parameter
+		+ Member
+		+ MaybeSerializeDeserialize
+		+ Ord
+		+ Default
+		+ Debug
+		+ Into<BalanceOf<Self>>;
+
+		/// The notion of time that will be used for vesting. Probably
+		/// either the relay chain or sovereign chain block number.
+		type VestingBlockProvider: BlockNumberProvider<BlockNumber = Self::VestingBlockNumber>;
 
 		type WeightInfo: WeightInfo;
 	}
@@ -149,10 +162,7 @@ pub mod pallet {
 		fn on_finalize(n: <T as frame_system::Config>::BlockNumber) {
 			// In the first block of the parachain we need to introduce the relay block related info
 			if n == 1u32.into() {
-				let slot = cumulus_pallet_parachain_system::Pallet::<T>::validation_data()
-					.expect("validation data was set in parachain system inherent")
-					.relay_parent_number;
-				<InitRelayBlock<T>>::put(slot);
+				<InitVestingBlock<T>>::put(T::VestingBlockProvider::current_block_number());
 			}
 		}
 	}
@@ -259,21 +269,19 @@ pub mod pallet {
 				Error::<T>::RewardsAlreadyClaimed
 			);
 
-			// Vesting is done in relation with the relay chain slot
-			let now = cumulus_pallet_parachain_system::Pallet::<T>::validation_data()
-				.expect("validation data was set in parachain system inherent")
-				.relay_parent_number;
+			// Get the current block used for vesting purposes
+			let now = T::VestingBlockProvider::current_block_number();
 
 			// Substract the first payment from the vested amount
 			let first_paid = T::InitializationPayment::get() * info.total_reward;
 
 			// To calculate how much could the user have claimed already
-			let payable_period = now.saturating_sub(<InitRelayBlock<T>>::get());
+			let payable_period = now.saturating_sub(<InitVestingBlock<T>>::get());
 
 			// How much should the contributor have already claimed by this block?
 			// By multiplying first we allow the conversion to integer done with the biggest number
-			let period = EndRelayBlock::<T>::get() - InitRelayBlock::<T>::get();
-			let should_have_claimed = if period == 0 {
+			let period = EndVestingBlock::<T>::get() - InitVestingBlock::<T>::get();
+			let should_have_claimed = if period == 0u32.into() {
 				// Pallet is configured with a zero vesting period.
 				info.total_reward - first_paid
 			} else {
@@ -343,7 +351,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::complete_initialization())]
 		pub fn complete_initialization(
 			origin: OriginFor<T>,
-			lease_ending_block: relay_chain::BlockNumber,
+			lease_ending_block: T::VestingBlockNumber,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 
@@ -357,7 +365,7 @@ pub mod pallet {
 
 			// This ensures the lease ending block is bigger than the init relay block
 			ensure!(
-				lease_ending_block > InitRelayBlock::<T>::get(),
+				lease_ending_block > InitVestingBlock::<T>::get(),
 				Error::<T>::VestingPeriodNonValid
 			);
 
@@ -381,7 +389,7 @@ pub mod pallet {
 			.expect("Shouldnt fail, as the fund should be enough to burn and nothing is locked");
 			drop(imbalance);
 
-			EndRelayBlock::<T>::put(lease_ending_block);
+			EndVestingBlock::<T>::put(lease_ending_block);
 
 			<Initialized<T>>::put(true);
 
@@ -602,12 +610,12 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn init_relay_block)]
 	/// Relay block height at the initialization of the pallet
-	type InitRelayBlock<T: Config> = StorageValue<_, relay_chain::BlockNumber, ValueQuery>;
+	type InitVestingBlock<T: Config> = StorageValue<_, T::VestingBlockNumber, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn end_relay_block)]
 	/// Relay block height at the initialization of the pallet
-	type EndRelayBlock<T: Config> = StorageValue<_, relay_chain::BlockNumber, ValueQuery>;
+	type EndVestingBlock<T: Config> = StorageValue<_, T::VestingBlockNumber, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn init_reward_amount)]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -134,6 +134,8 @@ impl Config for Test {
 	type MinimumReward = TestMinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
+	type VestingBlockNumber = RelayChainBlockNumber;
+	type VestingBlockProvider = cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;
 	type WeightInfo = ();
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -16,18 +16,11 @@
 
 //! Test utilities
 use crate::{self as pallet_crowdloan_rewards, Config};
-use cumulus_primitives_core::relay_chain::BlockNumber as RelayChainBlockNumber;
-use cumulus_primitives_core::PersistedValidationData;
-use cumulus_primitives_parachain_inherent::ParachainInherentData;
-use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 use frame_support::{
 	construct_runtime,
-	dispatch::UnfilteredDispatchable,
-	inherent::{InherentData, ProvideInherent},
 	parameter_types,
 	traits::{GenesisBuild, OnFinalize, OnInitialize},
 };
-use frame_system::RawOrigin;
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
 use sp_runtime::{

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -15,10 +15,9 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Test utilities
-use crate::{self as pallet_crowdloan_rewards, Config};
+use crate::{self as pallet_crowdloan_rewards, BlockProvider, Config};
 use frame_support::{
-	construct_runtime,
-	parameter_types,
+	construct_runtime, parameter_types,
 	traits::{GenesisBuild, OnFinalize, OnInitialize},
 };
 use sp_core::{ed25519, Pair, H256};
@@ -96,6 +95,19 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 
+use sp_runtime::traits::BlockNumberProvider;
+pub struct MockedBlockProvider;
+impl BlockProvider for MockedBlockProvider {
+	type BlockNumber = u64;
+
+	fn current_block_number() -> Self::BlockNumber {
+		System::current_block_number()
+	}
+
+	#[cfg(feature = "runtime-benchmarks")]
+	fn set_block_number(_block: Self::BlockNumber) {}
+}
+
 parameter_types! {
 	pub const TestMaxInitContributors: u32 = 8;
 	pub const TestMinimumReward: u128 = 0;
@@ -112,7 +124,7 @@ impl Config for Test {
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type VestingBlockNumber = <Self as frame_system::Config>::BlockNumber;
-	type VestingBlockProvider = System;
+	type VestingBlockProvider = MockedBlockProvider;
 	type WeightInfo = ();
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -186,39 +186,6 @@ pub(crate) fn batch_events() -> Vec<pallet_utility::Event> {
 
 pub(crate) fn roll_to(n: u64) {
 	while System::block_number() < n {
-		// Relay chain Stuff. I might actually set this to a number different than N
-		// let sproof_builder = RelayStateSproofBuilder::default();
-		// let (relay_parent_storage_root, relay_chain_state) =
-		// 	sproof_builder.into_state_root_and_proof();
-		// let vfp = PersistedValidationData {
-		// 	relay_parent_number: (System::block_number() + 1u64) as RelayChainBlockNumber,
-		// 	relay_parent_storage_root,
-		// 	..Default::default()
-		// };
-		// let inherent_data = {
-		// 	let mut inherent_data = InherentData::default();
-		// 	let system_inherent_data = ParachainInherentData {
-		// 		validation_data: vfp.clone(),
-		// 		relay_chain_state,
-		// 		downward_messages: Default::default(),
-		// 		horizontal_messages: Default::default(),
-		// 	};
-		// 	inherent_data
-		// 		.put_data(
-		// 			cumulus_primitives_parachain_inherent::INHERENT_IDENTIFIER,
-		// 			&system_inherent_data,
-		// 		)
-		// 		.expect("failed to put VFP inherent");
-		// 	inherent_data
-		// };
-
-		// ParachainSystem::on_initialize(System::block_number());
-		// ParachainSystem::create_inherent(&inherent_data)
-		// 	.expect("got an inherent")
-		// 	.dispatch_bypass_filter(RawOrigin::None.into())
-		// 	.expect("dispatch succeeded");
-		// ParachainSystem::on_finalize(System::block_number());
-
 		Crowdloan::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());
 		System::on_finalize(System::block_number());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -307,20 +307,20 @@ fn paying_works_after_unclaimed_period() {
 
 		// 1 is payable
 		assert!(Crowdloan::accounts_payable(&1).is_some());
-		roll_to(4);
+		roll_to(3);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 200);
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(3)),
 			Error::<Test>::NoAssociatedClaim
 		);
-		roll_to(5);
+		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 250);
-		roll_to(6);
+		roll_to(5);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 300);
-		roll_to(7);
+		roll_to(6);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 350);
 		roll_to(11);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -772,7 +772,7 @@ fn reward_below_vesting_period_works() {
 		// Block relay number is 2 post init initialization
 		// Here we should pay floor(0.625*2)=1
 		// Total claimed reward: 1+1 = 2
-		roll_to(4);
+		roll_to(3);
 
 		assert_ok!(Crowdloan::claim(Origin::signed(3)));
 
@@ -780,7 +780,7 @@ fn reward_below_vesting_period_works() {
 			Crowdloan::accounts_payable(&3).unwrap().claimed_reward,
 			2u128
 		);
-		roll_to(5);
+		roll_to(4);
 		// If we claim now we have to pay floor(0.625) = 0
 		assert_ok!(Crowdloan::claim(Origin::signed(3)));
 
@@ -788,7 +788,7 @@ fn reward_below_vesting_period_works() {
 			Crowdloan::accounts_payable(&3).unwrap().claimed_reward,
 			2u128
 		);
-		roll_to(6);
+		roll_to(5);
 		// Now we should pay 1 again. The claimer should have claimed floor(0.625*4) + 1
 		// but he only claimed 2
 		assert_ok!(Crowdloan::claim(Origin::signed(3)));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -188,7 +188,8 @@ fn initializing_multi_relay_to_single_native_address_works() {
 
 		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
-		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 400);
+		// Expect 500 clained (200 immediately + 100 per block for 3 blocks)
+		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 500);
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(3)),
 			Error::<Test>::NoAssociatedClaim
@@ -197,7 +198,7 @@ fn initializing_multi_relay_to_single_native_address_works() {
 		let expected = vec![
 			crate::Event::InitialPaymentMade(1, 100),
 			crate::Event::InitialPaymentMade(1, 100),
-			crate::Event::RewardsPaid(1, 200),
+			crate::Event::RewardsPaid(1, 300),
 		];
 		assert_eq!(events(), expected);
 	});

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -632,6 +632,8 @@ fn initialize_new_addresses_with_batch() {
 		);
 
 		let expected = vec![
+			pallet_utility::Event::ItemCompleted,
+			pallet_utility::Event::ItemCompleted,
 			pallet_utility::Event::BatchCompleted,
 			pallet_utility::Event::BatchInterrupted(
 				0,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -411,7 +411,7 @@ fn update_address_works() {
 			init_block + VESTING
 		));
 
-		roll_to(4);
+		roll_to(3);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(8)),
@@ -419,7 +419,7 @@ fn update_address_works() {
 		);
 		assert_ok!(Crowdloan::update_reward_address(Origin::signed(1), 8));
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 200);
-		roll_to(6);
+		roll_to(5);
 		assert_ok!(Crowdloan::claim(Origin::signed(8)));
 		assert_eq!(Crowdloan::accounts_payable(&8).unwrap().claimed_reward, 300);
 		// The initial payment is not
@@ -490,7 +490,7 @@ fn update_address_with_existing_with_multi_address_works() {
 			init_block + VESTING
 		));
 
-		roll_to(4);
+		roll_to(3);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 
 		// We make sure all rewards go to the new address

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,7 +25,7 @@ use sp_runtime::MultiSignature;
 
 // Constant that reflects the desired vesting period for the tests
 // Most tests complete initialization passing initRelayBlock + VESTING as the endRelayBlock
-const VESTING: u32 = 8;
+const VESTING: u64 = 8;
 
 #[test]
 fn geneses() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -650,7 +650,7 @@ fn initialize_new_addresses_with_batch() {
 }
 
 #[test]
-fn floating_point_arithmetic_works() {
+fn fixed_point_arithmetic_works() {
 	empty().execute_with(|| {
 		// The init relay block gets inserted
 		roll_to(2);
@@ -666,7 +666,8 @@ fn floating_point_arithmetic_works() {
 				Some(2),
 				1185
 			)])),
-			// We will work with this. This has 100/8=12.5 payable per block
+			// We will work with this contribution.
+			// This has 25 paid immediately and 100/8=12.5 payable per block
 			mock::Call::Crowdloan(crate::Call::initialize_reward_vec(vec![(
 				[3u8; 32].into(),
 				Some(3),
@@ -685,29 +686,28 @@ fn floating_point_arithmetic_works() {
 			25u128
 		);
 
-		// Block relay number is 2 post init initialization
+		// Vesting block number is 2 post init initialization
 		// In this case there is no problem. Here we pay 12.5*2=25
 		// Total claimed reward: 25+25 = 50
-		roll_to(4);
-
+		roll_to(3);
 		assert_ok!(Crowdloan::claim(Origin::signed(3)));
-
 		assert_eq!(
 			Crowdloan::accounts_payable(&3).unwrap().claimed_reward,
 			50u128
 		);
-		roll_to(5);
-		// If we claim now we have to pay 12.5. 12 will be paid.
-		assert_ok!(Crowdloan::claim(Origin::signed(3)));
 
+		// If we claim now we have to pay 12.5. 12 will be paid.
+		roll_to(4);
+		assert_ok!(Crowdloan::claim(Origin::signed(3)));
 		assert_eq!(
 			Crowdloan::accounts_payable(&3).unwrap().claimed_reward,
 			62u128
 		);
-		roll_to(6);
+		
 		// Now we should pay 12.5. However the calculus will be:
 		// Account 3 should have claimed 50 + 25 at this block, but
 		// he only claimed 62. The payment is 13
+		roll_to(5);
 		assert_ok!(Crowdloan::claim(Origin::signed(3)));
 		assert_eq!(
 			Crowdloan::accounts_payable(&3).unwrap().claimed_reward,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -228,32 +228,40 @@ fn paying_works_step_by_step() {
 		));
 		// 1 is payable
 		assert!(Crowdloan::accounts_payable(&1).is_some());
-		roll_to(4);
+
+		roll_to(3);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 200);
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(3)),
 			Error::<Test>::NoAssociatedClaim
 		);
-		roll_to(5);
+
+		roll_to(4);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 250);
-		roll_to(6);
+
+		roll_to(5);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 300);
-		roll_to(7);
+
+		roll_to(6);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 350);
-		roll_to(8);
+
+		roll_to(7);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 400);
-		roll_to(9);
+
+		roll_to(8);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 450);
-		roll_to(10);
+
+		roll_to(9);
 		assert_ok!(Crowdloan::claim(Origin::signed(1)));
 		assert_eq!(Crowdloan::accounts_payable(&1).unwrap().claimed_reward, 500);
-		roll_to(11);
+
+		roll_to(10);
 		assert_noop!(
 			Crowdloan::claim(Origin::signed(1)),
 			Error::<Test>::RewardsAlreadyClaimed


### PR DESCRIPTION
This PR is a followup to #43. It removes all dependencies (even dev-dependencies) on crates from cumulus.

Tests now use the parachain's own block number rather than the mocked relay number. This means that the `InitVestingBlock` was 1 rather than 2 as it was before. This caused most of the block indices to be off-by-one in tests that tested for specific vested amounts.