### PR TITLE
Add wrapped bytes to signature

### DIFF
--- a/src/benchmarks.rs
+++ b/src/benchmarks.rs
@@ -412,7 +412,7 @@ benchmarks! {
 		RelayPallet::<T>::on_finalize(T::BlockNumber::one());
 		Pallet::<T>::on_finalize(T::BlockNumber::one());
 
-	}:  _(RawOrigin::Root, second_reward_account.clone(), first_reward_account.clone(), proofs)
+	}:  _(RawOrigin::Signed(first_reward_account.clone()), second_reward_account.clone(), first_reward_account.clone(), proofs)
 	verify {
 		assert!(Pallet::<T>::accounts_payable(&second_reward_account).is_some());
 		assert_eq!(Pallet::<T>::accounts_payable(&second_reward_account).unwrap().total_reward, (100u32*x).into());

--- a/src/benchmarks.rs
+++ b/src/benchmarks.rs
@@ -410,7 +410,7 @@ benchmarks! {
 		RelayPallet::<T>::on_finalize(T::BlockNumber::one());
 		Pallet::<T>::on_finalize(T::BlockNumber::one());
 
-	}:  _(RawOrigin::Signed(first_reward_account.clone()), second_reward_account.clone(), first_reward_account.clone(), proofs)
+	}:  _(RawOrigin::Root, second_reward_account.clone(), first_reward_account.clone(), proofs)
 	verify {
 		assert!(Pallet::<T>::accounts_payable(&second_reward_account).is_some());
 		assert_eq!(Pallet::<T>::accounts_payable(&second_reward_account).unwrap().total_reward, (100u32*x).into());

--- a/src/benchmarks.rs
+++ b/src/benchmarks.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "runtime-benchmarks")]
 
-use crate::{BalanceOf, Call, Pallet};
+use crate::{BalanceOf, Call, Pallet, WRAPPED_BYTES};
 use cumulus_pallet_parachain_system::Pallet as RelayPallet;
 use cumulus_primitives_core::{
 	relay_chain::{v1::HeadData, BlockNumber as RelayChainBlockNumber},
@@ -378,8 +378,10 @@ benchmarks! {
 		let mut proofs: Vec<(T::RelayChainAccountId, MultiSignature)> = Vec::new();
 
 		// Construct payload
-		let mut payload = second_reward_account.clone().encode();
+		let mut payload = WRAPPED_BYTES.to_vec();
+		payload.append(&mut second_reward_account.clone().encode());
 		payload.append(&mut first_reward_account.clone().encode());
+		payload.append(&mut WRAPPED_BYTES.to_vec());
 
 		// Create N sigs for N accounts
 		for i in 0..x {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,9 @@ pub mod pallet {
 			+ From<AccountId32>
 			+ Ord;
 
+		// The origin that is allowed to change the reward address with relay signatures
+		type RewardAddressChangeOrigin: EnsureOrigin<Self::Origin>;
+
 		/// The type that will be used to track vesting progress
 		type VestingBlockNumber: AtLeast32BitUnsigned + Parameter + Default + Into<BalanceOf<Self>>;
 
@@ -260,7 +263,8 @@ pub mod pallet {
 			previous_account: T::AccountId,
 			proofs: Vec<(T::RelayChainAccountId, MultiSignature)>,
 		) -> DispatchResultWithPostInfo {
-			ensure_root(origin)?;
+			// Check that the origin is the one able to change the reward addrss
+			T::RewardAddressChangeOrigin::ensure_origin(origin)?;
 
 			// For now I prefer that we dont support providing an existing account here
 			ensure!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ pub mod pallet {
 		/// The number of valid proofs needs to be bigger than 'RewardAddressRelayVoteThreshold'
 		/// The account to be changed needs to be submitted as 'previous_account'
 
-		/// Only root-callable
+		/// Origin must be RewardAddressChangeOrigin
 		#[pallet::weight(T::WeightInfo::change_association_with_relay_keys(proofs.len() as u32))]
 		pub fn change_association_with_relay_keys(
 			origin: OriginFor<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub mod pallet {
 
 	pub const PALLET_ID: PalletId = PalletId(*b"Crowdloa");
 
+	// The wrapper around which the reward changing message needs to be wrapped
 	pub const WRAPPED_BYTES: &[u8] = b"<Bytes>";
 
 	/// Configuration trait of this pallet.

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -27,7 +27,7 @@ use frame_support::{
 	parameter_types,
 	traits::{GenesisBuild, OnFinalize, OnInitialize},
 };
-use frame_system::RawOrigin;
+use frame_system::{EnsureSigned, RawOrigin};
 use sp_core::{ed25519, Pair, H256};
 use sp_io;
 use sp_runtime::{
@@ -136,6 +136,8 @@ impl Config for Test {
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type RewardAddressRelayVoteThreshold = TestRewardAddressRelayVoteThreshold;
+	// The origin that is allowed to change the reward
+	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type VestingBlockNumber = RelayChainBlockNumber;
 	type VestingBlockProvider =
 		cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -952,21 +952,10 @@ fn test_relay_signatures_can_change_reward_addresses() {
 			insufficient_proofs.push((pairs[i].public().into(), pairs[i].sign(&payload).into()));
 		}
 
-		// Ensure non-root cannot change
-		assert_noop!(
-			Crowdloan::change_association_with_relay_keys(
-				Origin::signed(1),
-				2,
-				1,
-				insufficient_proofs.clone()
-			),
-			DispatchError::BadOrigin
-		);
-
 		// Not sufficient proofs presented
 		assert_noop!(
 			Crowdloan::change_association_with_relay_keys(
-				Origin::root(),
+				Origin::signed(1),
 				2,
 				1,
 				insufficient_proofs.clone()
@@ -982,7 +971,7 @@ fn test_relay_signatures_can_change_reward_addresses() {
 
 		// This time should pass
 		assert_ok!(Crowdloan::change_association_with_relay_keys(
-			Origin::root(),
+			Origin::signed(1),
 			2,
 			1,
 			sufficient_proofs.clone()


### PR DESCRIPTION
It wraps the signature to change the reward address through relay keys around "<Bytes>", to be compatible with polkadot-js extension. Additionally adds a new trait to ensure the caller of the reward address change extrinsic is the one we dictate in the runtime