### PR TITLE
Update associate native identity with wrap bytes (#49)

### DIFF
--- a/src/benchmarks.rs
+++ b/src/benchmarks.rs
@@ -329,8 +329,14 @@ benchmarks! {
 		// The caller that will associate the account
 		let caller: T::AccountId = create_funded_user::<T>("user", SEED, 100u32.into());
 
+		// Construct payload
+		let mut payload = WRAPPED_BYTES_PREFIX.to_vec();
+		payload.append(&mut T::SignatureNetworkIdentifier::get().to_vec());
+		payload.append(&mut caller.clone().encode());
+		payload.append(&mut WRAPPED_BYTES_POSTFIX.to_vec());
+
 		// Create a fake sig for such an account
-		let (relay_account, signature) = create_sig::<T>(SEED, caller.clone().encode());
+		let (relay_account, signature) = create_sig::<T>(SEED, payload);
 
 		// We verified there is no dependency of the number of contributors already inserted in associate_native_identity
 		// Create 1 contributor
@@ -379,6 +385,7 @@ benchmarks! {
 
 		// Construct payload
 		let mut payload = WRAPPED_BYTES_PREFIX.to_vec();
+		payload.append(&mut T::SignatureNetworkIdentifier::get().to_vec());
 		payload.append(&mut second_reward_account.clone().encode());
 		payload.append(&mut first_reward_account.clone().encode());
 		payload.append(&mut WRAPPED_BYTES_POSTFIX.to_vec());

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -125,6 +125,7 @@ parameter_types! {
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 	pub const TestRewardAddressRelayVoteThreshold: Perbill = Perbill::from_percent(50);
+	pub const TestSigantureNetworkIdentifier: &'static [u8] = b"test-";
 }
 
 impl Config for Test {
@@ -136,8 +137,12 @@ impl Config for Test {
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type RewardAddressRelayVoteThreshold = TestRewardAddressRelayVoteThreshold;
+	// The origin that is allowed to associate the reward
+	type RewardAddressAssociateOrigin = EnsureSigned<Self::AccountId>;
 	// The origin that is allowed to change the reward
 	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
+	type SignatureNetworkIdentifier = TestSigantureNetworkIdentifier;
+
 	type VestingBlockNumber = RelayChainBlockNumber;
 	type VestingBlockProvider =
 		cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -77,7 +77,11 @@ fn geneses() {
 #[test]
 fn proving_assignation_works() {
 	let pairs = get_ed25519_pairs(3);
-	let signature: MultiSignature = pairs[0].sign(&3u64.encode()).into();
+	let mut payload = WRAPPED_BYTES_PREFIX.to_vec();
+	payload.append(&mut TestSigantureNetworkIdentifier::get().to_vec());
+	payload.append(&mut 3u64.encode());
+	payload.append(&mut WRAPPED_BYTES_POSTFIX.to_vec());
+	let signature: MultiSignature = pairs[0].sign(&payload).into();
 	let alread_associated_signature: MultiSignature = pairs[0].sign(&1u64.encode()).into();
 	empty().execute_with(|| {
 		// Insert contributors
@@ -354,7 +358,11 @@ fn paying_works_after_unclaimed_period() {
 #[test]
 fn paying_late_joiner_works() {
 	let pairs = get_ed25519_pairs(3);
-	let signature: MultiSignature = pairs[0].sign(&3u64.encode()).into();
+	let mut payload = WRAPPED_BYTES_PREFIX.to_vec();
+	payload.append(&mut TestSigantureNetworkIdentifier::get().to_vec());
+	payload.append(&mut 3u64.encode());
+	payload.append(&mut WRAPPED_BYTES_POSTFIX.to_vec());
+	let signature: MultiSignature = pairs[0].sign(&payload).into();
 	empty().execute_with(|| {
 		// Insert contributors
 		let pairs = get_ed25519_pairs(3);
@@ -943,6 +951,7 @@ fn test_relay_signatures_can_change_reward_addresses() {
 		// Threshold is set to 50%, so we need at least 3 votes to pass
 		// Let's make sure that we dont pass with 2
 		let mut payload = WRAPPED_BYTES_PREFIX.to_vec();
+		payload.append(&mut TestSigantureNetworkIdentifier::get().to_vec());
 		payload.append(&mut 2u64.encode());
 		payload.append(&mut 1u64.encode());
 		payload.append(&mut WRAPPED_BYTES_POSTFIX.to_vec());


### PR DESCRIPTION
* Update associate native identity with wrap bytes
Cherry-picking https://github.com/PureStake/crowdloan-rewards/pull/49 to 0.9.12
* Add also to benchmark

* Update lock and formatter

* Add Network identifier to signature to prevent replay attacks

* Typo