### PR TITLE
Update rust compiler version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-09-10"
+channel = "nightly-2022-02-20"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
The rust compiler version in `rust-toolchain` has become quite old. This may fix #55.